### PR TITLE
hide personally flagged posts+comments from a users feed

### DIFF
--- a/src/Comments.Comment.jsx
+++ b/src/Comments.Comment.jsx
@@ -8,6 +8,8 @@ const parentItem = content.item;
 const highlight = !!props.highlight;
 const raw = !!props.raw;
 
+State.init({ hasBeenFlagged: false });
+
 const extractNotifyAccountId = (parentItem) => {
   if (!parentItem || parentItem.type !== "social" || !parentItem.path) {
     return undefined;
@@ -68,6 +70,14 @@ const Actions = styled.div`
   gap: 12px;
   margin: -6px -6px 6px;
 `;
+
+if (state.hasBeenFlagged) {
+  return (
+    <div className="alert alert-secondary">
+      <i className="bi bi-flag" /> This content has been flagged for moderation
+    </div>
+  );
+}
 
 return (
   <Comment>
@@ -150,6 +160,9 @@ return (
                 type: "social",
                 path: `${accountId}/post/comment`,
                 blockHeight,
+              },
+              onFlag: () => {
+                State.update({ hasBeenFlagged: true });
               },
             }}
           />

--- a/src/FlagButton.jsx
+++ b/src/FlagButton.jsx
@@ -46,10 +46,9 @@ return (
             },
           },
           {
-            // onCommit: () => {
-            //TODO kick off refresh or hide the item once we have
-            // updated the feed to filter flagged items
-            // },
+            onCommit: () => {
+              props.onFlag && props.onFlag();
+            },
           }
         );
       }}

--- a/src/Posts.Post.jsx
+++ b/src/Posts.Post.jsx
@@ -5,6 +5,8 @@ const subscribe = !!props.subscribe;
 const notifyAccountId = accountId;
 const postUrl = `https://alpha.near.org/#/near/widget/PostPage?accountId=${accountId}&blockHeight=${blockHeight}`;
 
+State.init({ hasBeenFlagged: false });
+
 const content =
   props.content ??
   JSON.parse(Social.get(`${accountId}/post/main`, blockHeight) ?? "null");
@@ -71,6 +73,14 @@ const Comments = styled.div`
     padding-top: 12px;
   }
 `;
+
+if (state.hasBeenFlagged) {
+  return (
+    <div className="alert alert-secondary">
+      <i className="bi bi-flag" /> This content has been flagged for moderation
+    </div>
+  );
+}
 
 return (
   <Post>
@@ -147,6 +157,9 @@ return (
             src="near/widget/FlagButton"
             props={{
               item,
+              onFlag: () => {
+                State.update({ hasBeenFlagged: true });
+              },
             }}
           />
         </Actions>


### PR DESCRIPTION
desktop view immediately upon flagging
![Screenshot 2023-04-12 at 2 16 47 PM](https://user-images.githubusercontent.com/24904709/231550758-fbbd8984-9f54-4786-aefd-614e2e126b55.png)

mobile
![IMG_0494](https://user-images.githubusercontent.com/24904709/231550931-df2fd6e0-c1b5-42fe-8a1e-fd6320fad6b4.PNG)

on subsequent loads the content will be hidden entirely