### PR TITLE
Updated Default Profile Pic

### DIFF
--- a/src/Posts.Compose.jsx
+++ b/src/Posts.Compose.jsx
@@ -342,7 +342,7 @@ return (
               image: profile.image,
               alt: profile.name,
               fallbackUrl:
-                "https://ipfs.near.social/ipfs/bafkreibmiy4ozblcgv3fm3gc6q62s55em33vconbavfd2ekkuliznaq3zm",
+                "https://ipfs.near.social/ipfs/bafkreibiyqabm3kl24gcb2oegb7pmwdi6wwrpui62iwb44l7uomnn3lhbi",
             }}
           />
         </Avatar>

--- a/src/ProfilePage.jsx
+++ b/src/ProfilePage.jsx
@@ -160,7 +160,7 @@ return (
             image: profile.backgroundImage,
             alt: "profile background image",
             fallbackUrl:
-              "https://ipfs.near.social/ipfs/bafkreibmiy4ozblcgv3fm3gc6q62s55em33vconbavfd2ekkuliznaq3zm",
+              "https://ipfs.near.social/ipfs/bafkreibiyqabm3kl24gcb2oegb7pmwdi6wwrpui62iwb44l7uomnn3lhbi",
           }}
         />
       )}


### PR DESCRIPTION
We have a minor inconsistency across widgets, were sometimes we show a profile image, and sometimes other. This PR fixes it, changing the previously default "dude with glasses" to a more abstract symbol depicting a person, which is used in all new widgets by Pagoda.

See the expected result here: 

https://alpha.near.org/ae40cb52839f896de8ec2313e5d7ef5f3b05b9ebc474329fa3456eec32126055/widget/Images