### PR TITLE
Implement custom notifications

### DIFF
--- a/src/Notification.jsx
+++ b/src/Notification.jsx
@@ -3,26 +3,6 @@ const { type } = value;
 const item = value?.item || {};
 const path = item.path || "";
 
-let notificationMessage = {
-  follow: "Followed you",
-  unfollow: "Unfollowed you",
-  poke: "Poked you",
-  like: isPost ? "Liked your post" : isComment ? "Liked your comment" : "",
-  comment: "Commented on your post",
-  mention: "Mentioned you",
-  custom: value.message ?? "",
-};
-
-// DevGov handles their own type
-if (type && type.startsWith("devgovgigs/")) {
-  return (
-    <Widget src="mob.near/widget/Notification.Item.DevGov" props={props} />
-  );
-}
-
-// Assert is a valid type
-if (!(type in notificationMessage) || !notificationMessage[type]) return <></>;
-
 // Build notification
 const isComment = path.indexOf("/post/comment") > 0 || type === "comment";
 const isPost = !isComment && path.indexOf("/post/main") > 0;
@@ -46,6 +26,16 @@ const actionable =
   type === "comment" ||
   type === "mention" ||
   type === "custom";
+
+let notificationMessage = {
+  follow: "Followed you",
+  unfollow: "Unfollowed you",
+  poke: "Poked you",
+  like: isPost ? "Liked your post" : isComment ? "Liked your comment" : "",
+  comment: "Commented on your post",
+  mention: "Mentioned you",
+  custom: value.message ?? "",
+};
 
 const Wrapper = styled.div`
   display: flex;
@@ -160,6 +150,16 @@ const Button = styled.a`
     font-size: 16px;
   }
 `;
+
+// DevGov handles their own type
+if (type && type.startsWith("devgovgigs/")) {
+  return (
+    <Widget src="mob.near/widget/Notification.Item.DevGov" props={props} />
+  );
+}
+
+// Assert is a valid type
+if (!(type in notificationMessage) || !notificationMessage[type]) return <></>;
 
 return (
   <>


### PR DESCRIPTION
This commit adds a new type of notification (called "custom"), that allow developers to tailor notifications for their application.

Custom notifications are defined by: a widget, a message, and a set of parameters. The end-user will be shown the message, while the "View" button will take the user to the widget passing the parameters as props.