### PR TITLE
Discussions in Components Details

### DIFF
--- a/src/ComponentDetailsPage.jsx
+++ b/src/ComponentDetailsPage.jsx
@@ -216,6 +216,13 @@ return (
       >
         History
       </TabsButton>
+
+      <TabsButton
+        href={`${detailsUrl}&tab=discussion`}
+        selected={state.selectedTab === "discussion"}
+      >
+        Discussion
+      </TabsButton>
     </Tabs>
 
     {state.selectedTab === "about" && (
@@ -317,6 +324,15 @@ return (
           props={{ widgetPath: src }}
         />
       </HistoryContainer>
+    )}
+
+    {state.selectedTab === "discussion" && (
+      <Content>
+        <Widget
+          src="near/widget/NestedDiscussions"
+          props={{ identifier: src }}
+        />
+      </Content>
     )}
   </Wrapper>
 );


### PR DESCRIPTION
Added discussion tabs on component's details page. Each component will have its own discussion. See example [here](https://alpha.near.org/ae40cb52839f896de8ec2313e5d7ef5f3b05b9ebc474329fa3456eec32126055/widget/ComponentDetailsPage?src=near/widget/NestedDiscussions&tab=discussion)