### PR TITLE
Fix for notifications with no parameters

### DIFF
--- a/src/Notification.jsx
+++ b/src/Notification.jsx
@@ -16,7 +16,7 @@ let postUrl = "";
 if (type !== "custom") {
   postUrl = `/#/near/widget/PostPage?accountId=${accountId}&${urlBlockHeight}=${blockHeight}`;
 } else {
-  postUrl = `/#/${value.widget}?${Object.entries(value.params)
+  postUrl = `/#/${value.widget}?${Object.entries(value.params || {})
     .map(([k, v]) => `${k}=${v}`)
     .join("&")}`;
 }


### PR DESCRIPTION
The current implementation raises an error on custom notifications that have no parameters since `undefined cannot be converted to an Object`