### PR TITLE
Better discussions

### DIFF
--- a/src/ComponentDetailsPage.jsx
+++ b/src/ComponentDetailsPage.jsx
@@ -330,7 +330,13 @@ return (
       <Content>
         <Widget
           src="near/widget/NestedDiscussions"
-          props={{ identifier: src, notifyAccountId: accountId }}
+          props={{
+            identifier: src,
+            notifyAccountId: accountId,
+            parentComponent: "near/widget/ComponentDetailsPage",
+            parentParams: { tab: "discussion" },
+            highlightComment: props.highlightComment
+          }}
         />
       </Content>
     )}

--- a/src/NestedDiscussions.jsx
+++ b/src/NestedDiscussions.jsx
@@ -1,10 +1,12 @@
 const identifier = props.identifier;
 const notifyAccountId = props.notifyAccountId;
-const dbAction = props.dbAction || "discuss";
+const highlightComment = props.highlightComment;
 const moderatorAccount = props.moderatorAccount || "bosmod.near";
-const composeWidget = props.composeWidget || "near/widget/NestedDiscussions.Compose";
-const previewWidget = props.previewWidget || "near/widget/NestedDiscussions.Preview";
-const notLoggedMessage = props.notLoggedMessage || "Please login to join the discussion";
+const placeholder = props.placeholder || "Join the discussion";
+
+// discussions happen inside other components
+const parentComponent = props.parentComponent;
+const parentParams = { ...props.parentParams };
 
 if (!identifier) {
   return "[NestedDiscussions]: Please setup an identifier for the discussion";
@@ -35,27 +37,55 @@ const FeedWrapper = styled.div`
   }
 `;
 
+const Highlight = styled.div`
+  a {
+    position: fixed;
+    bottom: 1.2rem;
+    right: 1.2rem;
+    background: var(--bs-link-color);
+    color: white;
+    padding: 0.3rem 0.6rem;
+    border-radius: 12px;
+    z-index: 99;
+  }
+
+  a:hover {
+    color: white;
+  }
+`;
+
 return (
   <DiscussionContainer>
     {context.accountId ? (
       <ComposeWrapper>
         <Widget
-          src={composeWidget}
-          props={{ dbAction, identifier, previewWidget, notifyAccountId }}
+          src="near/widget/NestedDiscussions.Compose"
+          props={{
+            placeholder,
+            indexKey: identifier,
+            notificationWidget: parentComponent,
+            notificationParams: parentParams,
+            notifyAccountId,
+          }}
         />
       </ComposeWrapper>
     ) : (
-      <p> {notLoggedMessage} </p>
+      <p> Login to {placeholder.toLowerCase()} </p>
+    )}
+    {highlightComment && (
+      <Highlight>
+        <a href="#highlight">Jump to highlighted comment</a>
+      </Highlight>
     )}
     <FeedWrapper>
       <Widget
         src="near/widget/NestedDiscussions.Feed"
         props={{
-          dbAction,
-          composeWidget,
-          previewWidget,
-          identifier,
+          indexKey: identifier,
           moderatorAccount,
+          parentComponent,
+          parentParams,
+          highlightComment,
         }}
       />
     </FeedWrapper>

--- a/src/NestedDiscussions/Feed.jsx
+++ b/src/NestedDiscussions/Feed.jsx
@@ -1,12 +1,13 @@
-const dbAction = props.dbAction;
-const composeWidget = props.composeWidget;
-const previewWidget = props.previewWidget;
-const identifier = props.identifier;
+const indexKey = props.indexKey;
 const moderatorAccount = props.moderatorAccount;
 
+const parentComponent = props.parentComponent;
+const parentParams = props.parentParams;
+const highlightComment = props.highlightComment;
+
 const index = {
-  action: dbAction,
-  key: identifier,
+  action: "discuss",
+  key: indexKey,
   options: { subscribe: true },
 };
 
@@ -18,22 +19,21 @@ const Post = styled.div`
   }
 `;
 
-const renderItem = (a) =>
-  a.value.type === "md" && (
-    <Post className="post" key={JSON.stringify(a)}>
-      <Widget
-        src={previewWidget}
-        props={{
-          accountId: a.accountId,
-          blockHeight: a.blockHeight,
-          dbAction,
-          composeWidget,
-          previewWidget,
-          moderatorAccount,
-        }}
-      />
-    </Post>
-  );
+const renderItem = ({ accountId, blockHeight }) => (
+  <Post className="post">
+    <Widget
+      src="near/widget/NestedDiscussions.Preview"
+      props={{
+        accountId,
+        blockHeight,
+        moderatorAccount,
+        parentComponent,
+        parentParams,
+        highlightComment,
+      }}
+    />
+  </Post>
+);
 
 return (
   <>

--- a/src/NestedDiscussions/Preview/CommentButton.jsx
+++ b/src/NestedDiscussions/Preview/CommentButton.jsx
@@ -1,4 +1,4 @@
-const comments = Social.index(props.dbAction, props.item);
+const comments = Social.index("discuss", props.item);
 const totalComments = comments?.length || 0;
 
 const CommentButton = styled.button`

--- a/src/NestedDiscussions/Preview/LikeButton.jsx
+++ b/src/NestedDiscussions/Preview/LikeButton.jsx
@@ -1,3 +1,6 @@
+const notificationComponent = props.notificationComponent;
+const notificationParams = props.notificationParams;
+const notifyAccountId = props.notifyAccountId;
 const item = props.item;
 
 if (!item) {
@@ -84,15 +87,14 @@ const likeClick = () => {
     },
   };
 
-  if (!hasLike && props.notifyAccountId) {
+  if (!hasLike && notifyAccountId) {
     data.index.notify = JSON.stringify({
-      key: props.notifyAccountId,
+      key: notifyAccountId,
       value: {
         type: "custom",
-        message: "Liked your discussion comment",
-        widget: props.previewWidget,
-        blockHeight: item.blockHeight,
-        params: item,
+        message: "Liked your comment",
+        widget: notificationComponent,
+        params: notificationParams,
       },
     });
   }


### PR DESCRIPTION
Before this PR notifications of discussions would show only one comment (the one referred by the notification). This is a problem in discussions, since the people need context to discuss.

Now, the notifications send the user back to the discussion, highlighting which comment is the notification referring to.

Changing this behaviour for better has also actually helped to simplify the discussions component a lot. 