### PR TITLE
fixed missing src param

### DIFF
--- a/src/ComponentDetailsPage.jsx
+++ b/src/ComponentDetailsPage.jsx
@@ -334,7 +334,7 @@ return (
             identifier: src,
             notifyAccountId: accountId,
             parentComponent: "near/widget/ComponentDetailsPage",
-            parentParams: { tab: "discussion" },
+            parentParams: { tab: "discussion", src },
             highlightComment: props.highlightComment
           }}
         />


### PR DESCRIPTION
Custom notifications for discussion lead to a broken link, since the `src` parameter is missing.