### PR TITLE
Fixed undefined state

### DIFF
--- a/src/IndexFeed.jsx
+++ b/src/IndexFeed.jsx
@@ -113,7 +113,7 @@ const computeFetchFrom = (items, limit, previouslyFoundItems) => {
 
 const mergeItems = (newItems) => {
   const items = [
-    ...new Set([...newItems, ...state.items].map((i) => JSON.stringify(i))),
+    ...new Set([...newItems, ...(state.items || [])].map((i) => JSON.stringify(i))),
   ].map((i) => JSON.parse(i));
   items.sort((a, b) => a.blockHeight - b.blockHeight);
   if (index.options.order === "desc") {


### PR DESCRIPTION
Sometimes the variable `state.items` will go undefined, this commit is a _patch_ to the error, since I was **not able to find the root source**.

Testing different widgets in the vscode extension, I noticed that `state.items` will sometimes go `undefined`, stopping the Feed from loading widgets. However, despite all of my efforts, I was not able to trace where/when in the code `state.items` goes undefined.

I assume other people building their own viewers could find a similar error.