### PR TITLE
use proper preview on ProfileEditor

### DIFF
--- a/src/ProfileEditor.jsx
+++ b/src/ProfileEditor.jsx
@@ -88,7 +88,7 @@ return (
       <div className="col-lg-6">
         <div>
           <Widget
-            src="${REPL_MOB_2}/widget/ProfilePage"
+            src="${REPL_ACCOUNT}/widget/ProfilePage"
             props={{ accountId, profile: state.profile }}
           />
         </div>


### PR DESCRIPTION
this is actually a bug in production as well. On near.org, the profile page is `near/widget/ProfilePage` and from there you can open the editor which is `near/widget/ProfileEditor` but the preview displayed there does not show the correct ProfilePage component, it still references `mob.near/widget/ProfilePage`