### PR TITLE
DIG.Tooltip

### DIFF
--- a/src/DIG/Tooltip.jsx
+++ b/src/DIG/Tooltip.jsx
@@ -1,0 +1,56 @@
+let { content, contentProps, rootProps, trigger, wrapperStyle } = props;
+
+const delayDuration = rootProps?.delayDuration ?? 300;
+
+const Root = styled("Tooltip.Root")``;
+
+const Content = styled("Tooltip.Content")`
+  border-radius: 8px;
+  padding: 12px 16px;
+  font: var(--text-xs);
+  background: var(--white);
+  border: 1px solid var(--sand6);
+
+  &[data-state="delayed-open"] {
+    animation: show 200ms;
+  }
+
+  @keyframes show {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const Arrow = styled("Tooltip.Arrow")`
+  fill: white;
+  position: relative;
+  top: -1.5px;
+`;
+
+const ArrowBorder = styled("Tooltip.Arrow")`
+  fill: var(--sand6);
+`;
+
+const TriggerWrapper = styled.span`
+  display: inline-block;
+`;
+
+return (
+  <Tooltip.Provider>
+    <Root delayDuration={delayDuration} {...rootProps}>
+      <Tooltip.Trigger asChild>
+        <TriggerWrapper style={wrapperStyle}>{trigger}</TriggerWrapper>
+      </Tooltip.Trigger>
+
+      <Content sideOffset={6} {...contentProps}>
+        {content}
+        <ArrowBorder width={12} height={6} />
+        <Arrow width={12} height={6} />
+      </Content>
+    </Root>
+  </Tooltip.Provider>
+);

--- a/src/DIG/Tooltip.jsx
+++ b/src/DIG/Tooltip.jsx
@@ -10,6 +10,7 @@ const Content = styled("Tooltip.Content")`
   font: var(--text-xs);
   background: var(--white);
   border: 1px solid var(--sand6);
+  box-shadow: 0 1px 2px hsla(0, 0%, 0%, 0.06);
 
   &[data-state="delayed-open"] {
     animation: show 200ms;

--- a/src/DIG/Tooltip.metadata.json
+++ b/src/DIG/Tooltip.metadata.json
@@ -1,0 +1,7 @@
+{
+  "description": "A tooltip built with the Radix primitive: https://www.radix-ui.com/docs/primitives/components/tooltip\n\n### Example\n\n```jsx\nreturn (\n  <Widget\n    src=\"near/widget/DIG.Tooltip\"\n    props={{\n      content: \"This is my tooltip content.\",\n      trigger: (\n        <Widget src=\"near/widget/DIG.Button\" props={{ label: \"Hover Me\" }} />\n      ),\n    }}\n  />\n);\n```\n\n### Props\n\n`content`\n- type: string or JSX\n- required\n- Content displayed inside the tooltip\n\n`contentProps`\n- type: object\n- optional\n- Radix `Content` props: https://www.radix-ui.com/docs/primitives/components/tooltip#content \n\n`rootProps`\n- type: object\n- optional\n- Radix `Root` props: https://www.radix-ui.com/docs/primitives/components/tooltip#root\n\n`trigger`\n- type: JSX\n- required\n- Renders the element that will display the tooltip when hovered. This element will be wrapped with a `<span>` styled with `display: inline-block;`.\n\n`wrapperStyle`\n- type: object\n- optional\n- Override styles for the `<span>` element wrapping the `trigger`.",
+  "name": "DIG.Tooltip",
+  "tags": {
+    "dig": ""
+  }
+}


### PR DESCRIPTION
Example

```jsx
return (
  <Widget
    src="near/widget/DIG.Tooltip"
    props={{
      content: "This is my tooltip content.",
      trigger: (
        <Widget src="near/widget/DIG.Button" props={{ label: "Hover Me" }} />
      ),
    }}
  />
);
```