### PR TITLE
fix: Math.max with an undefined argument resulted in NaN where an integer was expected.

### DIFF
--- a/src/IndexFeed.jsx
+++ b/src/IndexFeed.jsx
@@ -85,7 +85,7 @@ const initialRenderLimit =
 const addDisplayCount = props.nextLimit ?? initialRenderLimit;
 
 index.options.limit = Math.min(
-  Math.max(initialRenderLimit + addDisplayCount * 2, index.options.limit),
+  Math.max(initialRenderLimit + addDisplayCount * 2, index.options.limit ?? 0),
   100
 );
 const reverse = !!props.reverse;


### PR DESCRIPTION
This either fixes the React Minify error completely, or is a step towards that direction.

once this is deployed into `develop` we can test the discussions component @ https://test.near.org/discom.testnet/widget/ComponentDetailsPage?src=discom.testnet/widget/ActivityPage&tab=discussion