### PR TITLE
feat: implement fallback to old feed that supports SocialAPI

### DIFF
--- a/src/ActivityPage.jsx
+++ b/src/ActivityPage.jsx
@@ -1,6 +1,63 @@
+const GRAPHQL_ENDPOINT = "https://near-queryapi.api.pagoda.co";
+
+let lastPostSocialApi = Social.index("post", "main", {
+  limit: 1,
+  order: "desc",
+});
+
 State.init({
+  // If QueryAPI Feed is lagging behind Social API, fallback to old widget.
+  shouldFallback: props.shouldFallback ?? false,
   selectedTab: props.tab || "posts",
 });
+
+function fetchGraphQL(operationsDoc, operationName, variables) {
+  return asyncFetch(`${GRAPHQL_ENDPOINT}/v1/graphql`, {
+    method: "POST",
+    headers: { "x-hasura-role": "dataplatform_near" },
+    body: JSON.stringify({
+      query: operationsDoc,
+      variables: variables,
+      operationName: operationName,
+    }),
+  });
+}
+
+const lastPostQuery = `
+query IndexerQuery {
+  dataplatform_near_social_feed_posts( limit: 1, order_by: { block_height: desc }) {
+      block_height 
+  }
+}
+`;
+
+fetchGraphQL(lastPostQuery, "IndexerQuery", {})
+  .then((feedIndexerResponse) => {
+    if (
+      feedIndexerResponse &&
+      feedIndexerResponse.body.data.dataplatform_near_social_feed_posts.length >
+        0
+    ) {
+      const nearSocialBlockHeight = lastPostSocialApi[0].blockHeight;
+      const feedIndexerBlockHeight =
+        feedIndexerResponse.body.data.dataplatform_near_social_feed_posts[0]
+          .block_height;
+
+      const lag = nearSocialBlockHeight - feedIndexerBlockHeight;
+      let shouldFallback = lag > 2 || !feedIndexerBlockHeight;
+      State.update({ shouldFallback });
+    } else {
+      console.log("Falling back to old widget.");
+      State.update({ shouldFallback: true });
+    }
+  })
+  .catch((error) => {
+    console.log(
+      "Error while fetching GraphQL(falling back to old widget): ",
+      error
+    );
+    State.update({ shouldFallback: true });
+  });
 
 if (props.tab && props.tab !== state.selectedTab) {
   State.update({
@@ -140,13 +197,17 @@ return (
         <Widget src="${REPL_ACCOUNT}/widget/LatestComponents" />
       </Section>
       <Section negativeMargin primary active={state.selectedTab === "posts"}>
-        <Widget
-          src={`${REPL_ACCOUNT}/widget/Posts`}
-          props={{
-            GRAPHQL_ENDPOINT,
-            accountsFollowing,
-          }}
-        />
+        {state.shouldFallback == true ? (
+          <Widget src={`${REPL_ACCOUNT}/widget/v1.Posts`} />
+        ) : (
+          <Widget
+            src={`${REPL_ACCOUNT}/widget/Posts`}
+            props={{
+              GRAPHQL_ENDPOINT,
+              accountsFollowing,
+            }}
+          />
+        )}
       </Section>
       <Section active={state.selectedTab === "explore"}>
         <Widget src="${REPL_ACCOUNT}/widget/ExploreWidgets" />

--- a/src/v1/Feed.jsx
+++ b/src/v1/Feed.jsx
@@ -1,0 +1,30 @@
+// Copy of old version of feed from src/Feed.jsx
+const index = {
+  action: "post",
+  key: "main",
+  options: {
+    limit: 10,
+    order: "desc",
+    accountId: props.accounts,
+  },
+};
+
+const Post = styled.div`
+  border-bottom: 1px solid #eceef0;
+`;
+
+const renderItem = (a) =>
+  a.value.type === "md" && (
+    <Post key={JSON.stringify(a)}>
+      <Widget
+        src="${REPL_ACCOUNT}/widget/v1.Posts.Post"
+        props={{ accountId: a.accountId, blockHeight: a.blockHeight }}
+      />
+    </Post>
+  );
+
+return (
+  <div>
+    <Widget src="${REPL_MOB_2}/widget/IndexFeed" props={{ index, renderItem }} />
+  </div>
+);

--- a/src/v1/Posts.jsx
+++ b/src/v1/Posts.jsx
@@ -1,0 +1,164 @@
+// Copy of old src/Posts.jsx
+State.init({
+  selectedTab: Storage.privateGet("selectedTab") || "all",
+});
+
+const previousSelectedTab = Storage.privateGet("selectedTab");
+
+if (previousSelectedTab && previousSelectedTab !== state.selectedTab) {
+  State.update({
+    selectedTab: previousSelectedTab,
+  });
+}
+
+let accounts = undefined;
+
+if (state.selectedTab === "following" && context.accountId) {
+  const graph = Social.keys(`${context.accountId}/graph/follow/*`, "final");
+  if (graph !== null) {
+    accounts = Object.keys(graph[context.accountId].graph.follow || {});
+    accounts.push(context.accountId);
+  } else {
+    accounts = [];
+  }
+} else {
+  accounts = undefined;
+}
+
+function selectTab(selectedTab) {
+  Storage.privateSet("selectedTab", selectedTab);
+  State.update({ selectedTab });
+}
+
+const H2 = styled.h2`
+  font-size: 19px;
+  line-height: 22px;
+  color: #11181c;
+  margin: 0 0 24px;
+  padding: 0 24px;
+
+  @media (max-width: 1024px) {
+    display: none;
+  }
+`;
+
+const Content = styled.div`
+  @media (max-width: 1024px) {
+    > div:first-child {
+      border-top: none;
+    }
+  }
+`;
+
+const ComposeWrapper = styled.div`
+  border-top: 1px solid #eceef0;
+`;
+
+const FilterWrapper = styled.div`
+  border-top: 1px solid #eceef0;
+  padding: 24px 24px 0;
+
+  @media (max-width: 1024px) {
+    padding: 12px;
+  }
+`;
+
+const PillSelect = styled.div`
+  display: inline-flex;
+  align-items: center;
+
+  @media (max-width: 600px) {
+    width: 100%;
+
+    button {
+      flex: 1;
+    }
+  }
+`;
+
+const PillSelectButton = styled.button`
+  display: block;
+  position: relative;
+  border: 1px solid #e6e8eb;
+  border-right: none;
+  padding: 3px 24px;
+  border-radius: 0;
+  font-size: 12px;
+  line-height: 18px;
+  color: ${(p) => (p.selected ? "#fff" : "#687076")};
+  background: ${(p) => (p.selected ? "var(--violet10) !important" : "#FBFCFD")};
+  font-weight: 600;
+  transition: all 200ms;
+
+  &:hover {
+    background: #ecedee;
+    text-decoration: none;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--violet10) !important;
+    box-shadow: 0 0 0 1px var(--violet10);
+    z-index: 5;
+  }
+
+  &:first-child {
+    border-radius: 6px 0 0 6px;
+  }
+  &:last-child {
+    border-radius: 0 6px 6px 0;
+    border-right: 1px solid #e6e8eb;
+  }
+`;
+
+const FeedWrapper = styled.div`
+  .post {
+    padding-left: 24px;
+    padding-right: 24px;
+
+    @media (max-width: 1024px) {
+      padding-left: 12px;
+      padding-right: 12px;
+    }
+  }
+`;
+
+return (
+  <>
+    <H2>Posts</H2>
+
+    <Content>
+      {context.accountId && (
+        <>
+          <ComposeWrapper>
+            <Widget src="${REPL_ACCOUNT}/widget/Posts.Compose" />
+          </ComposeWrapper>
+
+          <FilterWrapper>
+            <PillSelect>
+              <PillSelectButton
+                type="button"
+                onClick={() => selectTab("all")}
+                selected={state.selectedTab === "all"}
+              >
+                All
+              </PillSelectButton>
+
+              <PillSelectButton
+                type="button"
+                onClick={() => selectTab("following")}
+                selected={state.selectedTab === "following"}
+              >
+                Following
+              </PillSelectButton>
+            </PillSelect>
+          </FilterWrapper>
+        </>
+      )}
+
+      <FeedWrapper>
+        <Widget src="${REPL_ACCOUNT}/widget/v1.Posts.Feed" props={{ accounts }} />
+      </FeedWrapper>
+    </Content>
+  </>
+);

--- a/src/v1/Posts/Feed.jsx
+++ b/src/v1/Posts/Feed.jsx
@@ -1,0 +1,36 @@
+// Copy of old version of feed from src/Posts/Feed.jsx
+const index = {
+  action: "post",
+  key: "main",
+  options: {
+    limit: 10,
+    order: "desc",
+    accountId: props.accounts,
+  },
+};
+
+const Post = styled.div`
+  border-bottom: 1px solid #eceef0;
+  padding: 24px 0 12px;
+
+  @media (max-width: 1024px) {
+    padding: 12px 0 0;
+  }
+`;
+
+const renderItem = (a) =>
+  a.value.type === "md" && (
+    <Post className="post" key={JSON.stringify(a)}>
+      <Widget
+        src="${REPL_ACCOUNT}/widget/v1.Posts.Post"
+        props={{ accountId: a.accountId, blockHeight: a.blockHeight }}
+      />
+    </Post>
+  );
+
+return (
+  <Widget
+    src="${REPL_ACCOUNT}/widget/IndexFeed"
+    props={{ index, renderItem, moderatorAccount: "${REPL_MODERATOR}" }}
+  />
+);

--- a/src/v1/Posts/Post.jsx
+++ b/src/v1/Posts/Post.jsx
@@ -1,0 +1,246 @@
+// Copy of old version of src/Posts/Post.jsx
+const accountId = props.accountId;
+const blockHeight =
+  props.blockHeight === "now" ? "now" : parseInt(props.blockHeight);
+const subscribe = !!props.subscribe;
+const notifyAccountId = accountId;
+const postUrl = `https://${REPL_NEAR_URL}/s/p?a=${accountId}&b=${blockHeight}`;
+
+State.init({ hasBeenFlagged: false });
+
+const edits = []; // Social.index('edit', { accountId, blockHeight }, { limit: 1, order: "desc", accountId })
+
+const content =
+  props.content ??
+  JSON.parse(
+    edits.length
+      ? Social.get(`${accountId}/edit/main`, edits.blockHeight)
+      : Social.get(`${accountId}/post/main`, blockHeight)
+  );
+
+const item = {
+  type: "social",
+  path: `${accountId}/post/main`,
+  blockHeight,
+};
+
+const toggleEdit = () => {
+  State.update({ editPost: !state.editPost });
+};
+
+const Post = styled.div`
+  position: relative;
+
+  &::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 19px;
+    top: 52px;
+    bottom: 12px;
+    width: 2px;
+    background: #eceef0;
+  }
+`;
+
+const Header = styled.div`
+  margin-bottom: 0;
+  display: inline-flex;
+`;
+
+const Body = styled.div`
+  padding-left: 52px;
+  padding-bottom: 1px;
+`;
+
+const Content = styled.div`
+  img {
+    display: block;
+    max-width: 100%;
+    max-height: 80vh;
+    margin: 0 0 12px;
+  }
+`;
+
+const Text = styled.p`
+  display: block;
+  margin: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  color: #687076;
+  white-space: nowrap;
+`;
+
+const Actions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: -6px -6px 6px;
+`;
+
+const Comments = styled.div`
+  > div > div:first-child {
+    padding-top: 12px;
+  }
+`;
+
+if (state.hasBeenFlagged) {
+  return (
+    <div className="alert alert-secondary">
+      <i className="bi bi-flag" /> This content has been flagged for moderation
+    </div>
+  );
+}
+
+return (
+  <Post>
+    <Header>
+      <div className="row">
+        <div className="col-auto">
+          <Widget
+            src="${REPL_ACCOUNT}/widget/AccountProfile"
+            props={{
+              accountId,
+              hideAccountId: true,
+              inlineContent: (
+                <>
+                  <Text as="span">･</Text>
+                  <Text>
+                    {blockHeight === "now" ? (
+                      "now"
+                    ) : (
+                      <>
+                        <Widget
+                          src="${REPL_MOB_2}/widget/TimeAgo"
+                          props={{ blockHeight }}
+                        />{" "}
+                        ago
+                      </>
+                    )}
+                  </Text>
+                  {false && edits.length > 0 && <Text as="span">･ Edited</Text>}
+                </>
+              ),
+            }}
+          />
+        </div>
+        <div className="col-1">
+          {false && (
+            <Widget
+              src="${REPL_ACCOUNT}/widget/Posts.Menu"
+              props={{
+                elements: [
+                  <button className={`btn`} onClick={toggleEdit}>
+                    <i className="bi bi-pencil me-1" />
+                    <span>Edit</span>
+                  </button>,
+                ],
+              }}
+            />
+          )}
+        </div>
+      </div>
+    </Header>
+
+    <Body>
+      <Content>
+        {content.text && !state.editPost && (
+          <Widget
+            src="${REPL_ACCOUNT}/widget/SocialMarkdown"
+            props={{ text: content.text }}
+          />
+        )}
+
+        {state.editPost && (
+          <div className="mb-2">
+            <Widget
+              src="${REPL_ACCOUNT}/widget/Posts.Edit"
+              props={{
+                item: { accountId, blockHeight },
+                content,
+                onEdit: toggleEdit,
+              }}
+            />
+          </div>
+        )}
+
+        {content.image && (
+          <Widget
+            src="${REPL_MOB}/widget/Image"
+            props={{
+              image: content.image,
+            }}
+          />
+        )}
+      </Content>
+
+      {blockHeight !== "now" && (
+        <Actions>
+          <Widget
+            src="${REPL_ACCOUNT}/widget/LikeButton"
+            props={{
+              item,
+              notifyAccountId,
+            }}
+          />
+          <Widget
+            src="${REPL_ACCOUNT}/widget/CommentButton"
+            props={{
+              item,
+              onClick: () => State.update({ showReply: !state.showReply }),
+            }}
+          />
+          <Widget
+            src="${REPL_ACCOUNT}/widget/CopyUrlButton"
+            props={{
+              url: postUrl,
+            }}
+          />
+          <Widget
+            src="${REPL_ACCOUNT}/widget/ShareButton"
+            props={{
+              postType: "post",
+              url: postUrl,
+            }}
+          />
+          <Widget
+            src="${REPL_ACCOUNT}/widget/FlagButton"
+            props={{
+              item,
+              onFlag: () => {
+                State.update({ hasBeenFlagged: true });
+              },
+            }}
+          />
+        </Actions>
+      )}
+
+      {state.showReply && (
+        <div className="mb-2">
+          <Widget
+            src="${REPL_ACCOUNT}/widget/Comments.Compose"
+            props={{
+              notifyAccountId,
+              item,
+              onComment: () => State.update({ showReply: false }),
+            }}
+          />
+        </div>
+      )}
+
+      <Comments>
+        <Widget
+          src="${REPL_ACCOUNT}/widget/Comments.Feed"
+          props={{
+            item,
+            highlightComment: props.highlightComment,
+            limit: props.commentsLimit,
+            subscribe,
+            raw,
+          }}
+        />
+      </Comments>
+    </Body>
+  </Post>
+);


### PR DESCRIPTION
We have recently adopted QueryAPI to power the near.org feed. QueryAPI is still in beta and there is a chance in the future that there is a time out or lag or issues relating to the service which could potentially cause downtime. 

To mitigate this, this PR implements a fallback mechanism by checking which of the two API's has the latest post: `QueryAPI` VS `SocialAPI`. It defaults to QueryAPI, but if the lag between the blockheight is more than 2, then it fallsback to the old widgets. 