### PR TITLE
Add `disabled` to FlagButton

### DIFF
--- a/src/AccountProfileOverlay.jsx
+++ b/src/AccountProfileOverlay.jsx
@@ -37,7 +37,8 @@ const Card = styled.div`
 const FollowButtonWrapper = styled.div`
   width: 100%;
 
-  div, button {
+  div,
+  button {
     width: 100%;
   }
 `;
@@ -61,6 +62,7 @@ const overlay = (
             src="${REPL_ACCOUNT}/widget/FlagButton"
             props={{
               item: contentModerationItem,
+              disabled: !context.accountId || context.accountId === accountId,
               onFlag: () => {
                 State.update({ hasBeenFlagged: true });
               },
@@ -110,12 +112,13 @@ return (
           props={{
             type: "info",
             title: "Flagged for moderation",
-            description: "Thanks for helping our Content Moderators. The item you flagged will be reviewed.",
+            description:
+              "Thanks for helping our Content Moderators. The item you flagged will be reviewed.",
             open: state.hasBeenFlagged,
             onOpenChange: (open) => {
               State.update({ hasBeenFlagged: open });
             },
-            duration: 10000
+            duration: 10000,
           }}
         />
       )}

--- a/src/Comments/Comment.jsx
+++ b/src/Comments/Comment.jsx
@@ -231,6 +231,7 @@ return (
                 path: `${accountId}/post/comment`,
                 blockHeight,
               },
+              disabled: !context.accountId || context.accountId === accountId,
               onFlag: () => {
                 State.update({ hasBeenFlagged: true });
               },

--- a/src/FlagButton.jsx
+++ b/src/FlagButton.jsx
@@ -1,4 +1,4 @@
-const { item } = props;
+const { item, disabled } = props;
 
 const Button = styled.button`
   border: 0;
@@ -24,36 +24,51 @@ const Button = styled.button`
     outline: none;
     color: #11181c;
   }
+
+  &[disabled] {
+    color: var(--sand8);
+    cursor: initial;
+  }
 `;
+
+const FlagButton = () => (
+  <Button
+    type="button"
+    aria-label="Flag for moderation"
+    disabled={disabled}
+    onClick={() => {
+      Social.set(
+        {
+          index: {
+            flag: JSON.stringify({
+              key: "main",
+              value: item,
+            }),
+          },
+        },
+        {
+          onCommit: () => {
+            props.onFlag && props.onFlag();
+          },
+        }
+      );
+    }}
+  >
+    <i className="bi bi-flag"></i>
+  </Button>
+);
+
+if (disabled) {
+  return (
+    <FlagButton />
+  );
+}
 
 return (
   <OverlayTrigger
     placement="top"
     overlay={<Tooltip>Flag for moderation</Tooltip>}
   >
-    <Button
-      type="button"
-      aria-label="Flag for moderation"
-      disabled={!context.accountId}
-      onClick={() => {
-        Social.set(
-          {
-            index: {
-              flag: JSON.stringify({
-                key: "main",
-                value: item,
-              }),
-            },
-          },
-          {
-            onCommit: () => {
-              props.onFlag && props.onFlag();
-            },
-          }
-        );
-      }}
-    >
-      <i className="bi bi-flag"></i>
-    </Button>
+    <FlagButton />
   </OverlayTrigger>
 );

--- a/src/NestedDiscussions/Preview.jsx
+++ b/src/NestedDiscussions/Preview.jsx
@@ -187,6 +187,7 @@ return (
                 path: `${accountId}/discuss`,
                 blockHeight,
               },
+              disabled: !context.accountId || context.accountId === accountId,
               onFlag: () => {
                 State.update({ hasBeenFlagged: true });
               },

--- a/src/Posts/Post.jsx
+++ b/src/Posts/Post.jsx
@@ -333,6 +333,7 @@ return (
             src="${REPL_ACCOUNT}/widget/FlagButton"
             props={{
               item,
+              disabled: !context.accountId || context.accountId === accountId,
               onFlag: () => {
                 State.update({ hasBeenFlagged: true });
               },

--- a/src/v1/Posts/Post.jsx
+++ b/src/v1/Posts/Post.jsx
@@ -208,6 +208,7 @@ return (
             src="${REPL_ACCOUNT}/widget/FlagButton"
             props={{
               item,
+              disabled: !context.accountId || context.accountId === accountId,
               onFlag: () => {
                 State.update({ hasBeenFlagged: true });
               },


### PR DESCRIPTION
Basically you can flag you own post, comment, discussion and account. Once you do that and open your profile page you'll see this error:

<img width="962" alt="Знімок екрана 2023-08-23 о 18 23 52" src="https://github.com/near/near-discovery-components/assets/34593263/366aed95-5d4c-4d81-b566-2b2380825457">
<img width="1162" alt="Знімок екрана 2023-08-23 о 18 24 00" src="https://github.com/near/near-discovery-components/assets/34593263/4d31ee25-ad22-4173-be3d-05bfd059c4ac">

Of course we have to handle it on the IndexFeed component but let's add a `disable` prop at first. 