### PR TITLE
Fix post preview

### DIFF
--- a/src/NestedDiscussions/Compose.jsx
+++ b/src/NestedDiscussions/Compose.jsx
@@ -349,7 +349,7 @@ return (
     {state.showPreview ? (
       <PreviewWrapper>
         <Widget
-          src="${REPL_ACCOUNT}/widget/Posts.Post"
+          src="${REPL_ACCOUNT}/widget/v1.Posts.Post"
           props={{
             accountId: context.accountId,
             blockHeight: "now",

--- a/src/Posts/Compose.jsx
+++ b/src/Posts/Compose.jsx
@@ -325,7 +325,7 @@ return (
     {state.showPreview ? (
       <PreviewWrapper>
         <Widget
-          src="${REPL_ACCOUNT}/widget/Posts.Post"
+          src="${REPL_ACCOUNT}/widget/v1.Posts.Post"
           props={{
             accountId: context.accountId,
             blockHeight: "now",

--- a/src/Posts/Edit.jsx
+++ b/src/Posts/Edit.jsx
@@ -314,7 +314,7 @@ if (!context.accountId) {
       {state.showPreview ? (
         <PreviewWrapper>
           <Widget
-            src="${REPL_ACCOUNT}/widget/Posts.Post"
+            src="${REPL_ACCOUNT}/widget/v1.Posts.Post"
             props={{
               accountId: context.accountId,
               blockHeight: "now",


### PR DESCRIPTION
After moving to QueryApi to upload posts feed we lost an ability preview posts when creating one. And the problem was simple: `Posts.Post` component returns "loading..." text if there is no such post. Which means we should use `v1.Posts.Post` for each component where we want to preview post because we don't need to make some call to preview post