### PR TITLE
Fix rendering posts on profile page

### DIFF
--- a/src/ProfilePage.jsx
+++ b/src/ProfilePage.jsx
@@ -240,7 +240,7 @@ return (
             )}
 
             <Widget
-              src="${REPL_ACCOUNT}/widget/v1.Posts.Feed"
+              src="${REPL_ACCOUNT}/widget/v1.Feed"
               props={{ accounts: [accountId] }}
             />
           </>


### PR DESCRIPTION
Closes: https://pagodaplatform.atlassian.net/browse/DEC-1444

There was a bug on profile page that user can't see any posts (maybe it was on my page only but I don't think so)

<img width="1162" alt="Знімок екрана 2023-08-23 о 18 24 00" src="https://github.com/near/near-discovery-components/assets/34593263/9e924e71-3a28-4ff4-ad53-d1f1a4f9a1c0">

I thought it's the problem of `IndexFeed` component and started to look for problem there in fact that it was working well earlier. I checked [this](https://near.org/near/widget/ComponentDetailsPage?src=mob.near/widget/IndexFeed) version of `IndexFeed` created and maintained by Eugene and the problem has gone.

Long story short: after we start using QueryAPI queries, this functional got broken too, and I fixed that by changing the src of component

`${REPL_ACCOUNT}/widget/Posts.Feed` -> `${REPL_ACCOUNT}/widget/v1.Posts.Feed`

but the thing is - I was wrong because I should change that to `${REPL_ACCOUNT}/widget/v1.Feed`. The reason of that before QueryAPI we've been storing `Feed` component in the **Posts** folder but than the whole **Posts** folder has been moved into the **v1** folder and that's why I pasted the wrong `src`. 