### PR TITLE
Fix styling prop of `NotificationAlert`

### DIFF
--- a/src/NearOrg/Notifications/NotificationAlert.jsx
+++ b/src/NearOrg/Notifications/NotificationAlert.jsx
@@ -52,9 +52,7 @@ const Description = () => (
 );
 
 const actionStyles = {
-  style: {
-    flexDirection: "column-reverse",
-  },
+  flexDirection: "column-reverse",
 };
 
 const CancelButton = ({ handleOnCancel }) => (


### PR DESCRIPTION
After #357 there are more items added to `DIG.Dialog`. See the whole list of props described [here](https://test.near.org/discom.testnet/widget/ComponentDetailsPage?src=discom.testnet/widget/DIG.Dialog).

But I want to highlight a few of them here:
- `actionStyles` - defined styles for buttons row. From now you can only pass css styles directly;
- `content` - pass your own content and it will be right after `title` and `description`. You can ignore passing `title` and `description` and provide your own elements with styling;
- `actionButtons` - allows to pass your own buttons or whatever you want (similar to `content`). This prop overrides action button properties given before so you have to define event handlers for each custom button by your own. Here is the whole list of ignored properties: `onCancel`, `onConfirm`, `cancelButtonText`, `confirmButtonText`, `cancelButton`, `confirmButton`.

All this information described in [DIG.Dialog](https://test.near.org/discom.testnet/widget/ComponentDetailsPage?src=discom.testnet/widget/DIG.Dialog).