### PR TITLE
#517 Moderate a post and first pass of new moderation page.

### DIFF
--- a/src/Moderation/ModerateAccounts.jsx
+++ b/src/Moderation/ModerateAccounts.jsx
@@ -4,97 +4,112 @@ const moderatorAccount = props?.moderatorAccount || "${REPL_MODERATOR}";
 const moderationStream = props.moderationStream || moderatorAccount;
 
 State.init({
-    inputContent: ""
+  inputContent: "",
 });
 
 function blockAccounts(input) {
-    let accountIds = input.split(",").map((a) => a.trim());
+  let accountIds = input.split(",").map((a) => a.trim());
 
-    return accountIds.map((accountId) =>
-        ({key: moderationStream, value: {path: accountId, label: 'moderate'}}), []);
+  return accountIds.map(
+    (accountId) => ({
+      key: moderationStream,
+      value: { path: accountId, label: "moderate" },
+    }),
+    [],
+  );
 }
 
 function unblockAccount(accountId) {
-    return JSON.stringify({key: moderationStream, value: {path: accountId, label: null, operation: 'delete'}});
+  return JSON.stringify({
+    key: moderationStream,
+    value: { path: accountId, label: null, operation: "delete" },
+  });
 }
 
 const moderatedObjects = context.accountId
-    ? Social.index("moderate", moderationStream, {subscribe: true, order: 'desc'})
-        .filter((f) => f.accountId === moderatorAccount)
-    : [];
+  ? Social.index("moderate", moderationStream, {
+      subscribe: true,
+      order: "desc",
+    }).filter((f) => f.accountId === moderatorAccount)
+  : [];
 const modifiedModerations = {}; // track update & delete operations
 
 return (
-    <>
-        <div className="d-flex flex-row gap-2 mb-5">
-        <span style={{color: "grey", float: left, paddingRight: '2em'}}>
-          When saving, ensure data is being written to moderator key. You may need
-          to refresh your browser if you used "Pretend to be another account" while
-          on this page
-        </span>
-            <input
-                type="text"
-                value={state.inputContent}
-                onChange={(e) => {
-                    State.update({
-                        inputContent: e.target.value,
-                    });
-                }}
-                placeholder="Comma-separated list of accounts"
-            />
-            <CommitButton
-                force
-                data={ {index: {moderate: blockAccounts(state.inputContent)} } }
-                onCommit={() => {
-                    State.update({inputContent: ""});
-                }}
-            >
-                Add to filter
-            </CommitButton>
+  <>
+    <div className="d-flex flex-row gap-2 mb-5">
+      <span style={{ color: "grey", float: left, paddingRight: "2em" }}>
+        When saving, ensure data is being written to moderator key. You may need
+        to refresh your browser if you used "Pretend to be another account"
+        while on this page
+      </span>
+      <input
+        type="text"
+        value={state.inputContent}
+        onChange={(e) => {
+          State.update({
+            inputContent: e.target.value,
+          });
+        }}
+        placeholder="Comma-separated list of accounts"
+      />
+      <CommitButton
+        force
+        data={{ index: { moderate: blockAccounts(state.inputContent) } }}
+        onCommit={() => {
+          State.update({ inputContent: "" });
+        }}
+      >
+        Add to filter
+      </CommitButton>
+    </div>
+    <h3>Moderated (blocked) Accounts</h3>
+    <table className="table">
+      <th>Account</th>
+      <th>Reason</th>
+      <th>Clear moderation</th>
+      <tbody>
+        {moderatedObjects &&
+          moderatedObjects.map((f) => {
+            if (!f || !f.value || !f.value.path) {
+              return;
+            }
 
-        </div>
-        <h3>Moderated (blocked) Accounts</h3>
-        <table className="table">
-            <th>Account</th>
-            <th>Reason</th>
-            <th>Clear moderation</th>
-            <tbody>
-            {moderatedObjects && moderatedObjects.map((f) => {
-                if(!f || !f.value || !f.value.path) {
-                    return
-                }
+            const account = f.value.path;
+            const mod = modifiedModerations[account];
+            if (mod && mod.operation === "delete") {
+              return;
+            }
 
-                const account = f.value.path;
-                const mod = modifiedModerations[account];
-                if(mod && mod.operation === 'delete') {
-                    return;
-                }
-
-                // todo account for longer sequences of operations
-                if(f.value.operation) {
-                    modifiedModerations[account] = {operation: f.value.operation, label: f.value.label};
-                } else {
-                    const label = mod && mod.operation === 'update' ? mod.label : f.value.label;
-                    return (
-                        <tr key={account}>
-                            <td>{account}</td>
-                            <td>{label}</td>
-                            <td>
-                                <CommitButton
-                                    className="btn btn-danger"
-                                    data={{
-                                        index: {
-                                            moderate: unblockAccount(account),
-                                        }
-                                    }}
-                                >
-                                    <i className="bi bi-x"/>
-                                </CommitButton>
-                            </td>
-                        </tr>
-                    )}})}
-            </tbody>
-        </table>
-
-    </>
+            // todo account for longer sequences of operations
+            if (f.value.operation) {
+              modifiedModerations[account] = {
+                operation: f.value.operation,
+                label: f.value.label,
+              };
+            } else {
+              const label =
+                mod && mod.operation === "update" ? mod.label : f.value.label;
+              return (
+                <tr key={account}>
+                  <td>{account}</td>
+                  <td>{label}</td>
+                  <td>
+                    <CommitButton
+                      className="btn btn-danger"
+                      data={{
+                        index: {
+                          moderate: unblockAccount(account),
+                        },
+                      }}
+                    >
+                      <i className="bi bi-x" />
+                    </CommitButton>
+                  </td>
+                </tr>
+              );
+            }
+          })}
+      </tbody>
+    </table>
+  </>
 );

--- a/src/Moderation/ModerateAccounts.jsx
+++ b/src/Moderation/ModerateAccounts.jsx
@@ -1,0 +1,100 @@
+// noinspection JSAnnotator
+
+const moderatorAccount = props?.moderatorAccount || "${REPL_MODERATOR}";
+const moderationStream = props.moderationStream || moderatorAccount;
+
+State.init({
+    inputContent: ""
+});
+
+function blockAccounts(input) {
+    let accountIds = input.split(",").map((a) => a.trim());
+
+    return accountIds.map((accountId) =>
+        ({key: moderationStream, value: {path: accountId, label: 'moderate'}}), []);
+}
+
+function unblockAccount(accountId) {
+    return JSON.stringify({key: moderationStream, value: {path: accountId, label: null, operation: 'delete'}});
+}
+
+const moderatedObjects = context.accountId
+    ? Social.index("moderate", moderationStream, {subscribe: true, order: 'desc'})
+        .filter((f) => f.accountId === moderatorAccount)
+    : [];
+const modifiedModerations = {}; // track update & delete operations
+
+return (
+    <>
+        <div className="d-flex flex-row gap-2 mb-5">
+        <span style={{color: "grey", float: left, paddingRight: '2em'}}>
+          When saving, ensure data is being written to moderator key. You may need
+          to refresh your browser if you used "Pretend to be another account" while
+          on this page
+        </span>
+            <input
+                type="text"
+                value={state.inputContent}
+                onChange={(e) => {
+                    State.update({
+                        inputContent: e.target.value,
+                    });
+                }}
+                placeholder="Comma-separated list of accounts"
+            />
+            <CommitButton
+                force
+                data={ {index: {moderate: blockAccounts(state.inputContent)} } }
+                onCommit={() => {
+                    State.update({inputContent: ""});
+                }}
+            >
+                Add to filter
+            </CommitButton>
+
+        </div>
+        <h3>Moderated (blocked) Accounts</h3>
+        <table className="table">
+            <th>Account</th>
+            <th>Reason</th>
+            <th>Clear moderation</th>
+            <tbody>
+            {moderatedObjects && moderatedObjects.map((f) => {
+                if(!f || !f.value || !f.value.path) {
+                    return
+                }
+
+                const account = f.value.path;
+                const mod = modifiedModerations[account];
+                if(mod && mod.operation === 'delete') {
+                    return;
+                }
+
+                // todo account for longer sequences of operations
+                if(f.value.operation) {
+                    modifiedModerations[account] = {operation: f.value.operation, label: f.value.label};
+                } else {
+                    const label = mod && mod.operation === 'update' ? mod.label : f.value.label;
+                    return (
+                        <tr key={account}>
+                            <td>{account}</td>
+                            <td>{label}</td>
+                            <td>
+                                <CommitButton
+                                    className="btn btn-danger"
+                                    data={{
+                                        index: {
+                                            moderate: unblockAccount(account),
+                                        }
+                                    }}
+                                >
+                                    <i className="bi bi-x"/>
+                                </CommitButton>
+                            </td>
+                        </tr>
+                    )}})}
+            </tbody>
+        </table>
+
+    </>
+);

--- a/src/Moderation/ModerateComments.jsx
+++ b/src/Moderation/ModerateComments.jsx
@@ -1,115 +1,144 @@
 // noinspection JSAnnotator
 
 const moderatorAccount = props?.moderatorAccount || "${REPL_MODERATOR}";
-const objectPath = '/post/comment';
-const moderationStream = (props.moderationStream || moderatorAccount) + objectPath;
+const objectPath = "/post/comment";
+const moderationStream =
+  (props.moderationStream || moderatorAccount) + objectPath;
 
 State.init({
-    accountInput: "", blockInput: ""
+  accountInput: "",
+  blockInput: "",
 });
 
 function blockComment(accountId, blockHeight) {
-    const account = accountId.trim();
-    const block = blockHeight.trim();
+  const account = accountId.trim();
+  const block = blockHeight.trim();
 
-    return JSON.stringify({key: moderationStream, value: {path: `${account}${objectPath}`, blockHeight: block, label: 'moderate'}})
+  return JSON.stringify({
+    key: moderationStream,
+    value: {
+      path: `${account}${objectPath}`,
+      blockHeight: block,
+      label: "moderate",
+    },
+  });
 }
 
 function unblockComment(accountId, blockHeight) {
-    return JSON.stringify({key: moderationStream, value: {path: `${accountId}${objectPath}`, blockHeight: blockHeight, label: null, operation: 'delete'}});
+  return JSON.stringify({
+    key: moderationStream,
+    value: {
+      path: `${accountId}${objectPath}`,
+      blockHeight: blockHeight,
+      label: null,
+      operation: "delete",
+    },
+  });
 }
 
 const moderatedObjects = context.accountId
-    ? Social.index("moderate", moderationStream, {subscribe: true, order: 'desc'})
-        // .filter((f) => f.accountId === moderatorAccount)
-    : [];
+  ? Social.index("moderate", moderationStream, {
+      subscribe: true,
+      order: "desc",
+    })
+  : // .filter((f) => f.accountId === moderatorAccount)
+    [];
 const modifiedModerations = {}; // track update & delete operations
 
 return (
-    <>
-        <div className="d-flex flex-row gap-2 mb-5">
-        <span style={{color: "grey", float: left, paddingRight: '2em'}}>
-          When saving, ensure data is being written to moderator key. You may need
-          to refresh your browser if you used "Pretend to be another account" while
-          on this page
-        </span>
-            <input
-                type="text"
-                value={state.accountInput}
-                onChange={(e) => {
-                    State.update({
-                        accountInput: e.target.value,
-                    });
-                }}
-                placeholder="The account of the comment to moderate"
-            />
-            <input
-                type="text"
-                value={state.blockInput}
-                onChange={(e) => {
-                    State.update({
-                        blockInput: e.target.value,
-                    });
-                }}
-                placeholder="The block height of the comment to moderate"
-            />
+  <>
+    <div className="d-flex flex-row gap-2 mb-5">
+      <span style={{ color: "grey", float: left, paddingRight: "2em" }}>
+        When saving, ensure data is being written to moderator key. You may need
+        to refresh your browser if you used "Pretend to be another account"
+        while on this page
+      </span>
+      <input
+        type="text"
+        value={state.accountInput}
+        onChange={(e) => {
+          State.update({
+            accountInput: e.target.value,
+          });
+        }}
+        placeholder="The account of the comment to moderate"
+      />
+      <input
+        type="text"
+        value={state.blockInput}
+        onChange={(e) => {
+          State.update({
+            blockInput: e.target.value,
+          });
+        }}
+        placeholder="The block height of the comment to moderate"
+      />
 
-            <CommitButton
-                force
-                data={ {index: {moderate: blockComment(state.accountInput, state.blockInput)} } }
-                onCommit={() => {
-                    State.update({accountInput: "", blockInput: ""});
-                }}
-            >
-                Add to filter
-            </CommitButton>
+      <CommitButton
+        force
+        data={{
+          index: {
+            moderate: blockComment(state.accountInput, state.blockInput),
+          },
+        }}
+        onCommit={() => {
+          State.update({ accountInput: "", blockInput: "" });
+        }}
+      >
+        Add to filter
+      </CommitButton>
+    </div>
+    <h3>Moderated (blocked) Comments</h3>
+    <table className="table">
+      <th>Account</th>
+      <th>Block Height</th>
+      <th>Reason</th>
+      <th>Clear moderation</th>
+      <tbody>
+        {moderatedObjects &&
+          moderatedObjects.map((f) => {
+            if (!f || !f.value || !f.value.path || !f.value.blockHeight) {
+              return;
+            }
 
-        </div>
-        <h3>Moderated (blocked) Comments</h3>
-        <table className="table">
-            <th>Account</th>
-            <th>Block Height</th>
-            <th>Reason</th>
-            <th>Clear moderation</th>
-            <tbody>
-            {moderatedObjects && moderatedObjects.map((f) => {
-                if(!f || !f.value || !f.value.path || !f.value.blockHeight) {
-                    return
-                }
+            const account = f.value.path.split("/")[0];
+            const block = f.value.blockHeight;
+            const key = `${account}@${block}`;
+            const mod = modifiedModerations[key];
+            if (mod && mod.operation === "delete") {
+              return;
+            }
 
-                const account = f.value.path.split('/')[0];
-                const block = f.value.blockHeight;
-                const key = `${account}@${block}`;
-                const mod = modifiedModerations[key];
-                if(mod && mod.operation === 'delete') {
-                    return;
-                }
-
-                if(f.value.operation) {
-                    modifiedModerations[key] = {operation: f.value.operation, label: f.value.label};
-                } else {
-                    const label = mod && mod.operation === 'update' ? mod.label : f.value.label;
-                    return (
-                        <tr key={account}>
-                            <td>{account}</td>
-                            <td>{block}</td>
-                            <td>{label}</td>
-                            <td>
-                                <CommitButton
-                                    className="btn btn-danger"
-                                    data={{
-                                        index: {
-                                            moderate: unblockComment(account, block),
-                                        }
-                                    }}
-                                >
-                                    <i className="bi bi-x"/>
-                                </CommitButton>
-                            </td>
-                        </tr>
-                    )}})}
-            </tbody>
-        </table>
-
-    </>
+            if (f.value.operation) {
+              modifiedModerations[key] = {
+                operation: f.value.operation,
+                label: f.value.label,
+              };
+            } else {
+              const label =
+                mod && mod.operation === "update" ? mod.label : f.value.label;
+              return (
+                <tr key={account}>
+                  <td>{account}</td>
+                  <td>{block}</td>
+                  <td>{label}</td>
+                  <td>
+                    <CommitButton
+                      className="btn btn-danger"
+                      data={{
+                        index: {
+                          moderate: unblockComment(account, block),
+                        },
+                      }}
+                    >
+                      <i className="bi bi-x" />
+                    </CommitButton>
+                  </td>
+                </tr>
+              );
+            }
+          })}
+      </tbody>
+    </table>
+  </>
 );

--- a/src/Moderation/ModerateComments.jsx
+++ b/src/Moderation/ModerateComments.jsx
@@ -1,0 +1,115 @@
+// noinspection JSAnnotator
+
+const moderatorAccount = props?.moderatorAccount || "${REPL_MODERATOR}";
+const objectPath = '/post/comment';
+const moderationStream = (props.moderationStream || moderatorAccount) + objectPath;
+
+State.init({
+    accountInput: "", blockInput: ""
+});
+
+function blockComment(accountId, blockHeight) {
+    const account = accountId.trim();
+    const block = blockHeight.trim();
+
+    return JSON.stringify({key: moderationStream, value: {path: `${account}${objectPath}`, blockHeight: block, label: 'moderate'}})
+}
+
+function unblockComment(accountId, blockHeight) {
+    return JSON.stringify({key: moderationStream, value: {path: `${accountId}${objectPath}`, blockHeight: blockHeight, label: null, operation: 'delete'}});
+}
+
+const moderatedObjects = context.accountId
+    ? Social.index("moderate", moderationStream, {subscribe: true, order: 'desc'})
+        // .filter((f) => f.accountId === moderatorAccount)
+    : [];
+const modifiedModerations = {}; // track update & delete operations
+
+return (
+    <>
+        <div className="d-flex flex-row gap-2 mb-5">
+        <span style={{color: "grey", float: left, paddingRight: '2em'}}>
+          When saving, ensure data is being written to moderator key. You may need
+          to refresh your browser if you used "Pretend to be another account" while
+          on this page
+        </span>
+            <input
+                type="text"
+                value={state.accountInput}
+                onChange={(e) => {
+                    State.update({
+                        accountInput: e.target.value,
+                    });
+                }}
+                placeholder="The account of the comment to moderate"
+            />
+            <input
+                type="text"
+                value={state.blockInput}
+                onChange={(e) => {
+                    State.update({
+                        blockInput: e.target.value,
+                    });
+                }}
+                placeholder="The block height of the comment to moderate"
+            />
+
+            <CommitButton
+                force
+                data={ {index: {moderate: blockComment(state.accountInput, state.blockInput)} } }
+                onCommit={() => {
+                    State.update({accountInput: "", blockInput: ""});
+                }}
+            >
+                Add to filter
+            </CommitButton>
+
+        </div>
+        <h3>Moderated (blocked) Comments</h3>
+        <table className="table">
+            <th>Account</th>
+            <th>Block Height</th>
+            <th>Reason</th>
+            <th>Clear moderation</th>
+            <tbody>
+            {moderatedObjects && moderatedObjects.map((f) => {
+                if(!f || !f.value || !f.value.path || !f.value.blockHeight) {
+                    return
+                }
+
+                const account = f.value.path.split('/')[0];
+                const block = f.value.blockHeight;
+                const key = `${account}@${block}`;
+                const mod = modifiedModerations[key];
+                if(mod && mod.operation === 'delete') {
+                    return;
+                }
+
+                if(f.value.operation) {
+                    modifiedModerations[key] = {operation: f.value.operation, label: f.value.label};
+                } else {
+                    const label = mod && mod.operation === 'update' ? mod.label : f.value.label;
+                    return (
+                        <tr key={account}>
+                            <td>{account}</td>
+                            <td>{block}</td>
+                            <td>{label}</td>
+                            <td>
+                                <CommitButton
+                                    className="btn btn-danger"
+                                    data={{
+                                        index: {
+                                            moderate: unblockComment(account, block),
+                                        }
+                                    }}
+                                >
+                                    <i className="bi bi-x"/>
+                                </CommitButton>
+                            </td>
+                        </tr>
+                    )}})}
+            </tbody>
+        </table>
+
+    </>
+);

--- a/src/Moderation/ModeratePosts.jsx
+++ b/src/Moderation/ModeratePosts.jsx
@@ -1,115 +1,142 @@
 // noinspection JSAnnotator
 
 const moderatorAccount = props?.moderatorAccount || "${REPL_MODERATOR}";
-const objectPath = '/post/main';
-const moderationStream = (props.moderationStream || moderatorAccount) + objectPath;
+const objectPath = "/post/main";
+const moderationStream =
+  (props.moderationStream || moderatorAccount) + objectPath;
 
 State.init({
-    accountInput: "", blockInput: ""
+  accountInput: "",
+  blockInput: "",
 });
 
 function blockPost(accountId, blockHeight) {
-    const account = accountId.trim();
-    const block = blockHeight.trim();
+  const account = accountId.trim();
+  const block = blockHeight.trim();
 
-    return JSON.stringify({key: moderationStream, value: {path: `${account}${objectPath}`, blockHeight: block, label: 'moderate'}})
+  return JSON.stringify({
+    key: moderationStream,
+    value: {
+      path: `${account}${objectPath}`,
+      blockHeight: block,
+      label: "moderate",
+    },
+  });
 }
 
 function unblockPost(accountId, blockHeight) {
-    return JSON.stringify({key: moderationStream, value: {path: `${accountId}${objectPath}`, blockHeight: blockHeight, label: null, operation: 'delete'}});
+  return JSON.stringify({
+    key: moderationStream,
+    value: {
+      path: `${accountId}${objectPath}`,
+      blockHeight: blockHeight,
+      label: null,
+      operation: "delete",
+    },
+  });
 }
 
 const moderatedObjects = context.accountId
-    ? Social.index("moderate", moderationStream, {subscribe: true, order: 'desc'})
-        // .filter((f) => f.accountId === moderatorAccount)
-    : [];
+  ? Social.index("moderate", moderationStream, {
+      subscribe: true,
+      order: "desc",
+    })
+  : // .filter((f) => f.accountId === moderatorAccount)
+    [];
 const modifiedModerations = {}; // track update & delete operations
 
 return (
-    <>
-        <div className="d-flex flex-row gap-2 mb-5">
-        <span style={{color: "grey", float: left, paddingRight: '2em'}}>
-          When saving, ensure data is being written to moderator key. You may need
-          to refresh your browser if you used "Pretend to be another account" while
-          on this page
-        </span>
-            <input
-                type="text"
-                value={state.accountInput}
-                onChange={(e) => {
-                    State.update({
-                        accountInput: e.target.value,
-                    });
-                }}
-                placeholder="The account of the post to moderate"
-            />
-            <input
-                type="text"
-                value={state.blockInput}
-                onChange={(e) => {
-                    State.update({
-                        blockInput: e.target.value,
-                    });
-                }}
-                placeholder="The block height of the post to moderate"
-            />
+  <>
+    <div className="d-flex flex-row gap-2 mb-5">
+      <span style={{ color: "grey", float: left, paddingRight: "2em" }}>
+        When saving, ensure data is being written to moderator key. You may need
+        to refresh your browser if you used "Pretend to be another account"
+        while on this page
+      </span>
+      <input
+        type="text"
+        value={state.accountInput}
+        onChange={(e) => {
+          State.update({
+            accountInput: e.target.value,
+          });
+        }}
+        placeholder="The account of the post to moderate"
+      />
+      <input
+        type="text"
+        value={state.blockInput}
+        onChange={(e) => {
+          State.update({
+            blockInput: e.target.value,
+          });
+        }}
+        placeholder="The block height of the post to moderate"
+      />
 
-            <CommitButton
-                force
-                data={ {index: {moderate: blockPost(state.accountInput, state.blockInput)} } }
-                onCommit={() => {
-                    State.update({accountInput: "", blockInput: ""});
-                }}
-            >
-                Add to filter
-            </CommitButton>
+      <CommitButton
+        force
+        data={{
+          index: { moderate: blockPost(state.accountInput, state.blockInput) },
+        }}
+        onCommit={() => {
+          State.update({ accountInput: "", blockInput: "" });
+        }}
+      >
+        Add to filter
+      </CommitButton>
+    </div>
+    <h3>Moderated (blocked) Posts</h3>
+    <table className="table">
+      <th>Account</th>
+      <th>Block Height</th>
+      <th>Reason</th>
+      <th>Clear moderation</th>
+      <tbody>
+        {moderatedObjects &&
+          moderatedObjects.map((f) => {
+            if (!f || !f.value || !f.value.path || !f.value.blockHeight) {
+              return;
+            }
 
-        </div>
-        <h3>Moderated (blocked) Posts</h3>
-        <table className="table">
-            <th>Account</th>
-            <th>Block Height</th>
-            <th>Reason</th>
-            <th>Clear moderation</th>
-            <tbody>
-            {moderatedObjects && moderatedObjects.map((f) => {
-                if(!f || !f.value || !f.value.path || !f.value.blockHeight) {
-                    return
-                }
+            const account = f.value.path.split("/")[0];
+            const block = f.value.blockHeight;
+            const key = `${account}@${block}`;
+            const mod = modifiedModerations[key];
+            if (mod && mod.operation === "delete") {
+              return;
+            }
 
-                const account = f.value.path.split('/')[0];
-                const block = f.value.blockHeight;
-                const key = `${account}@${block}`;
-                const mod = modifiedModerations[key];
-                if(mod && mod.operation === 'delete') {
-                    return;
-                }
-
-                if(f.value.operation) {
-                    modifiedModerations[key] = {operation: f.value.operation, label: f.value.label};
-                } else {
-                    const label = mod && mod.operation === 'update' ? mod.label : f.value.label;
-                    return (
-                        <tr key={account}>
-                            <td>{account}</td>
-                            <td>{block}</td>
-                            <td>{label}</td>
-                            <td>
-                                <CommitButton
-                                    className="btn btn-danger"
-                                    data={{
-                                        index: {
-                                            moderate: unblockPost(account, block),
-                                        }
-                                    }}
-                                >
-                                    <i className="bi bi-x"/>
-                                </CommitButton>
-                            </td>
-                        </tr>
-                    )}})}
-            </tbody>
-        </table>
-
-    </>
+            if (f.value.operation) {
+              modifiedModerations[key] = {
+                operation: f.value.operation,
+                label: f.value.label,
+              };
+            } else {
+              const label =
+                mod && mod.operation === "update" ? mod.label : f.value.label;
+              return (
+                <tr key={account}>
+                  <td>{account}</td>
+                  <td>{block}</td>
+                  <td>{label}</td>
+                  <td>
+                    <CommitButton
+                      className="btn btn-danger"
+                      data={{
+                        index: {
+                          moderate: unblockPost(account, block),
+                        },
+                      }}
+                    >
+                      <i className="bi bi-x" />
+                    </CommitButton>
+                  </td>
+                </tr>
+              );
+            }
+          })}
+      </tbody>
+    </table>
+  </>
 );

--- a/src/Moderation/ModeratePosts.jsx
+++ b/src/Moderation/ModeratePosts.jsx
@@ -1,0 +1,115 @@
+// noinspection JSAnnotator
+
+const moderatorAccount = props?.moderatorAccount || "${REPL_MODERATOR}";
+const objectPath = '/post/main';
+const moderationStream = (props.moderationStream || moderatorAccount) + objectPath;
+
+State.init({
+    accountInput: "", blockInput: ""
+});
+
+function blockPost(accountId, blockHeight) {
+    const account = accountId.trim();
+    const block = blockHeight.trim();
+
+    return JSON.stringify({key: moderationStream, value: {path: `${account}${objectPath}`, blockHeight: block, label: 'moderate'}})
+}
+
+function unblockPost(accountId, blockHeight) {
+    return JSON.stringify({key: moderationStream, value: {path: `${accountId}${objectPath}`, blockHeight: blockHeight, label: null, operation: 'delete'}});
+}
+
+const moderatedObjects = context.accountId
+    ? Social.index("moderate", moderationStream, {subscribe: true, order: 'desc'})
+        // .filter((f) => f.accountId === moderatorAccount)
+    : [];
+const modifiedModerations = {}; // track update & delete operations
+
+return (
+    <>
+        <div className="d-flex flex-row gap-2 mb-5">
+        <span style={{color: "grey", float: left, paddingRight: '2em'}}>
+          When saving, ensure data is being written to moderator key. You may need
+          to refresh your browser if you used "Pretend to be another account" while
+          on this page
+        </span>
+            <input
+                type="text"
+                value={state.accountInput}
+                onChange={(e) => {
+                    State.update({
+                        accountInput: e.target.value,
+                    });
+                }}
+                placeholder="The account of the post to moderate"
+            />
+            <input
+                type="text"
+                value={state.blockInput}
+                onChange={(e) => {
+                    State.update({
+                        blockInput: e.target.value,
+                    });
+                }}
+                placeholder="The block height of the post to moderate"
+            />
+
+            <CommitButton
+                force
+                data={ {index: {moderate: blockPost(state.accountInput, state.blockInput)} } }
+                onCommit={() => {
+                    State.update({accountInput: "", blockInput: ""});
+                }}
+            >
+                Add to filter
+            </CommitButton>
+
+        </div>
+        <h3>Moderated (blocked) Posts</h3>
+        <table className="table">
+            <th>Account</th>
+            <th>Block Height</th>
+            <th>Reason</th>
+            <th>Clear moderation</th>
+            <tbody>
+            {moderatedObjects && moderatedObjects.map((f) => {
+                if(!f || !f.value || !f.value.path || !f.value.blockHeight) {
+                    return
+                }
+
+                const account = f.value.path.split('/')[0];
+                const block = f.value.blockHeight;
+                const key = `${account}@${block}`;
+                const mod = modifiedModerations[key];
+                if(mod && mod.operation === 'delete') {
+                    return;
+                }
+
+                if(f.value.operation) {
+                    modifiedModerations[key] = {operation: f.value.operation, label: f.value.label};
+                } else {
+                    const label = mod && mod.operation === 'update' ? mod.label : f.value.label;
+                    return (
+                        <tr key={account}>
+                            <td>{account}</td>
+                            <td>{block}</td>
+                            <td>{label}</td>
+                            <td>
+                                <CommitButton
+                                    className="btn btn-danger"
+                                    data={{
+                                        index: {
+                                            moderate: unblockPost(account, block),
+                                        }
+                                    }}
+                                >
+                                    <i className="bi bi-x"/>
+                                </CommitButton>
+                            </td>
+                        </tr>
+                    )}})}
+            </tbody>
+        </table>
+
+    </>
+);

--- a/src/Moderation/Moderator.jsx
+++ b/src/Moderation/Moderator.jsx
@@ -124,10 +124,9 @@ return(
             }
 
             {state.selectedTab === "moderated_comments" && (
-                <>
-                    <h2>Moderated Comments</h2>
-                    <h3>todo</h3>
-                </>
+                <Widget
+                    src={`${REPL_ACCOUNT}/widget/Moderation.ModerateComments`}
+                    props={{ moderatorAccount, moderationStream, }}/>
             )}
 
         </Content>

--- a/src/Moderation/Moderator.jsx
+++ b/src/Moderation/Moderator.jsx
@@ -1,0 +1,135 @@
+// noinspection JSAnnotator
+
+const Content = styled.div`
+  .post {
+  padding-left: 0;
+  padding-right: 0;
+  }
+`;
+const Tabs = styled.div`
+  display: flex;
+  height: 48px;
+  border-bottom: 1px solid #eceef0;
+  margin-bottom: 72px;
+  overflow: auto;
+  scroll-behavior: smooth;
+
+  @media (max-width: 1024px) {
+  background: #f8f9fa;
+  border-top: 1px solid #eceef0;
+  margin: 0 -12px 48px;
+
+  > * {
+    flex: 1;
+  }
+  }
+`;
+
+const TabsButton = styled.a`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-weight: 600;
+  font-size: 12px;
+  padding: 0 12px;
+  position: relative;
+  color: ${(p) => (p.selected ? "#11181C" : "#687076")};
+  background: none;
+  border: none;
+  outline: none;
+  text-align: center;
+  text-decoration: none !important;
+
+  &:hover {
+  color: #11181c;
+  }
+
+  &::after {
+  content: "";
+  display: ${(p) => (p.selected ? "block" : "none")};
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: #59e692;
+  }
+`;
+
+State.init({
+    selectedTab: props.tab || "reported",
+});
+if (props.tab && props.tab !== state.selectedTab) {
+    State.update({
+        selectedTab: props.tab,
+    });
+}
+
+const baseUrl = `#/${REPL_ACCOUNT}/widget/Moderation.Moderator?`;
+const moderatorAccount = 'buildnear.testnet'; // testing // props?.moderatorAccount || "${REPL_MODERATOR}";
+const moderationStream = props.moderationStream || moderatorAccount;
+
+return(
+    <div className="d-flex flex-column gap-5">
+        <span>Admin: {moderatorAccount}</span>
+        <Content>
+            <Tabs>
+                <TabsButton
+                    href={`${baseUrl}&tab=reported`}
+                    selected={state.selectedTab === "reported"}
+                >
+                    Reported and needs moderation
+                </TabsButton>
+
+                <TabsButton
+                    href={`${baseUrl}&tab=moderated_accounts`}
+                    selected={state.selectedTab === "moderated_accounts"}
+                >
+                    Moderated Accounts
+                </TabsButton>
+
+                <TabsButton
+                    href={`${baseUrl}&tab=moderated_posts`}
+                    selected={state.selectedTab === "moderated_posts"}
+                >
+                    Moderated Posts
+                </TabsButton>
+
+                <TabsButton
+                    href={`${baseUrl}&tab=moderated_comments`}
+                    selected={state.selectedTab === "moderated_comments"}
+                >
+                    Moderated Comments
+                </TabsButton>
+            </Tabs>
+
+            {state.selectedTab === "reported" && (
+                <Widget
+                    src="${REPL_ACCOUNT}/widget/Flagged.Feed"
+                />
+            )}
+
+
+            {state.selectedTab === "moderated_accounts" &&
+                <Widget
+                    src={`${REPL_ACCOUNT}/widget/Moderation.ModerateAccounts`}
+                    props={{ moderatorAccount, moderationStream, }}/>
+            }
+
+            {state.selectedTab === "moderated_posts" &&
+                <Widget
+                    src={`${REPL_ACCOUNT}/widget/Moderation.ModeratePosts`}
+                    props={{ moderatorAccount, moderationStream, }}/>
+            }
+
+            {state.selectedTab === "moderated_comments" && (
+                <>
+                    <h2>Moderated Comments</h2>
+                    <h3>todo</h3>
+                </>
+            )}
+
+        </Content>
+    </div>
+);

--- a/src/Moderation/Moderator.jsx
+++ b/src/Moderation/Moderator.jsx
@@ -66,7 +66,7 @@ if (props.tab && props.tab !== state.selectedTab) {
     });
 }
 
-const baseUrl = `#/${REPL_ACCOUNT}/widget/Moderation.Moderator?`;
+const baseUrl = `#/${REPL_ACCOUNT}/widget/Moderation.Moderator`;
 const moderatorAccount = props?.moderatorAccount || "${REPL_MODERATOR}";
 const moderationStream = props.moderationStream || moderatorAccount;
 
@@ -76,28 +76,28 @@ return(
         <Content>
             <Tabs>
                 <TabsButton
-                    href={`${baseUrl}&tab=reported`}
+                    href={`${baseUrl}?&tab=reported`}
                     selected={state.selectedTab === "reported"}
                 >
                     Reported and needs moderation
                 </TabsButton>
 
                 <TabsButton
-                    href={`${baseUrl}&tab=moderated_accounts`}
+                    href={`${baseUrl}?&tab=moderated_accounts`}
                     selected={state.selectedTab === "moderated_accounts"}
                 >
                     Moderated Accounts
                 </TabsButton>
 
                 <TabsButton
-                    href={`${baseUrl}&tab=moderated_posts`}
+                    href={`${baseUrl}?&tab=moderated_posts`}
                     selected={state.selectedTab === "moderated_posts"}
                 >
                     Moderated Posts
                 </TabsButton>
 
                 <TabsButton
-                    href={`${baseUrl}&tab=moderated_comments`}
+                    href={`${baseUrl}?&tab=moderated_comments`}
                     selected={state.selectedTab === "moderated_comments"}
                 >
                     Moderated Comments
@@ -113,19 +113,19 @@ return(
 
             {state.selectedTab === "moderated_accounts" &&
                 <Widget
-                    src={`${REPL_ACCOUNT}/widget/Moderation.ModerateAccounts`}
+                    src="${REPL_ACCOUNT}/widget/Moderation.ModerateAccounts"
                     props={{ moderatorAccount, moderationStream, }}/>
             }
 
             {state.selectedTab === "moderated_posts" &&
                 <Widget
-                    src={`${REPL_ACCOUNT}/widget/Moderation.ModeratePosts`}
+                    src="${REPL_ACCOUNT}/widget/Moderation.ModeratePosts"
                     props={{ moderatorAccount, moderationStream, }}/>
             }
 
             {state.selectedTab === "moderated_comments" && (
                 <Widget
-                    src={`${REPL_ACCOUNT}/widget/Moderation.ModerateComments`}
+                    src="${REPL_ACCOUNT}/widget/Moderation.ModerateComments"
                     props={{ moderatorAccount, moderationStream, }}/>
             )}
 

--- a/src/Moderation/Moderator.jsx
+++ b/src/Moderation/Moderator.jsx
@@ -2,8 +2,8 @@
 
 const Content = styled.div`
   .post {
-  padding-left: 0;
-  padding-right: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 `;
 const Tabs = styled.div`
@@ -15,13 +15,13 @@ const Tabs = styled.div`
   scroll-behavior: smooth;
 
   @media (max-width: 1024px) {
-  background: #f8f9fa;
-  border-top: 1px solid #eceef0;
-  margin: 0 -12px 48px;
+    background: #f8f9fa;
+    border-top: 1px solid #eceef0;
+    margin: 0 -12px 48px;
 
-  > * {
-    flex: 1;
-  }
+    > * {
+      flex: 1;
+    }
   }
 `;
 
@@ -42,93 +42,92 @@ const TabsButton = styled.a`
   text-decoration: none !important;
 
   &:hover {
-  color: #11181c;
+    color: #11181c;
   }
 
   &::after {
-  content: "";
-  display: ${(p) => (p.selected ? "block" : "none")};
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: #59e692;
+    content: "";
+    display: ${(p) => (p.selected ? "block" : "none")};
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: #59e692;
   }
 `;
 
 State.init({
-    selectedTab: props.tab || "reported",
+  selectedTab: props.tab || "reported",
 });
 if (props.tab && props.tab !== state.selectedTab) {
-    State.update({
-        selectedTab: props.tab,
-    });
+  State.update({
+    selectedTab: props.tab,
+  });
 }
 
 const baseUrl = `#/${REPL_ACCOUNT}/widget/Moderation.Moderator`;
 const moderatorAccount = props?.moderatorAccount || "${REPL_MODERATOR}";
 const moderationStream = props.moderationStream || moderatorAccount;
 
-return(
-    <div className="d-flex flex-column gap-5">
-        <span>Admin: {moderatorAccount}</span>
-        <Content>
-            <Tabs>
-                <TabsButton
-                    href={`${baseUrl}?&tab=reported`}
-                    selected={state.selectedTab === "reported"}
-                >
-                    Reported and needs moderation
-                </TabsButton>
+return (
+  <div className="d-flex flex-column gap-5">
+    <span>Admin: {moderatorAccount}</span>
+    <Content>
+      <Tabs>
+        <TabsButton
+          href={`${baseUrl}?&tab=reported`}
+          selected={state.selectedTab === "reported"}
+        >
+          Reported and needs moderation
+        </TabsButton>
 
-                <TabsButton
-                    href={`${baseUrl}?&tab=moderated_accounts`}
-                    selected={state.selectedTab === "moderated_accounts"}
-                >
-                    Moderated Accounts
-                </TabsButton>
+        <TabsButton
+          href={`${baseUrl}?&tab=moderated_accounts`}
+          selected={state.selectedTab === "moderated_accounts"}
+        >
+          Moderated Accounts
+        </TabsButton>
 
-                <TabsButton
-                    href={`${baseUrl}?&tab=moderated_posts`}
-                    selected={state.selectedTab === "moderated_posts"}
-                >
-                    Moderated Posts
-                </TabsButton>
+        <TabsButton
+          href={`${baseUrl}?&tab=moderated_posts`}
+          selected={state.selectedTab === "moderated_posts"}
+        >
+          Moderated Posts
+        </TabsButton>
 
-                <TabsButton
-                    href={`${baseUrl}?&tab=moderated_comments`}
-                    selected={state.selectedTab === "moderated_comments"}
-                >
-                    Moderated Comments
-                </TabsButton>
-            </Tabs>
+        <TabsButton
+          href={`${baseUrl}?&tab=moderated_comments`}
+          selected={state.selectedTab === "moderated_comments"}
+        >
+          Moderated Comments
+        </TabsButton>
+      </Tabs>
 
-            {state.selectedTab === "reported" && (
-                <Widget
-                    src="${REPL_ACCOUNT}/widget/Flagged.Feed"
-                />
-            )}
+      {state.selectedTab === "reported" && (
+        <Widget src="${REPL_ACCOUNT}/widget/Flagged.Feed" />
+      )}
 
+      {state.selectedTab === "moderated_accounts" && (
+        <Widget
+          src="${REPL_ACCOUNT}/widget/Moderation.ModerateAccounts"
+          props={{ moderatorAccount, moderationStream }}
+        />
+      )}
 
-            {state.selectedTab === "moderated_accounts" &&
-                <Widget
-                    src="${REPL_ACCOUNT}/widget/Moderation.ModerateAccounts"
-                    props={{ moderatorAccount, moderationStream, }}/>
-            }
+      {state.selectedTab === "moderated_posts" && (
+        <Widget
+          src="${REPL_ACCOUNT}/widget/Moderation.ModeratePosts"
+          props={{ moderatorAccount, moderationStream }}
+        />
+      )}
 
-            {state.selectedTab === "moderated_posts" &&
-                <Widget
-                    src="${REPL_ACCOUNT}/widget/Moderation.ModeratePosts"
-                    props={{ moderatorAccount, moderationStream, }}/>
-            }
-
-            {state.selectedTab === "moderated_comments" && (
-                <Widget
-                    src="${REPL_ACCOUNT}/widget/Moderation.ModerateComments"
-                    props={{ moderatorAccount, moderationStream, }}/>
-            )}
-
-        </Content>
-    </div>
+      {state.selectedTab === "moderated_comments" && (
+        <Widget
+          src="${REPL_ACCOUNT}/widget/Moderation.ModerateComments"
+          props={{ moderatorAccount, moderationStream }}
+        />
+      )}
+    </Content>
+  </div>
 );

--- a/src/Moderation/Moderator.jsx
+++ b/src/Moderation/Moderator.jsx
@@ -67,7 +67,7 @@ if (props.tab && props.tab !== state.selectedTab) {
 }
 
 const baseUrl = `#/${REPL_ACCOUNT}/widget/Moderation.Moderator?`;
-const moderatorAccount = 'buildnear.testnet'; // testing // props?.moderatorAccount || "${REPL_MODERATOR}";
+const moderatorAccount = props?.moderatorAccount || "${REPL_MODERATOR}";
 const moderationStream = props.moderationStream || moderatorAccount;
 
 return(


### PR DESCRIPTION
 * Tabbed moderation page
 * Moderate a post feature
 * Moderate a comment feature
 * Un-moderate actions write a delete operation to the index. This is applied in the UI.
 * Moderation actions are written in SocialDB index format

> Moderate account
> ```
> {
>   "bosmod.near": {
>     "index": {
>       "moderate": "[{\"key\":\"bosmod.near\",\"value\":{\"path\":\"badaccount.near\",\"label\":\"moderate\"}}]"
>     }
>   }
> }
> ```
> 
> Moderate post
> ```
> {
>   "bosmod.near": {
>     "index": {
>       "moderate": "{\"key\":\"bosmod.near/post/main\",\"value\":{\"path\":\"badaccount.near/post/main\",\"blockHeight\":\"95781851\",\"label\":\"moderate\"}}"
>     }
>   }
> }
> ```
> 
> Moderate comment
> ```
> {
>   "bosmod.near": {
>     "index": {
>       "moderate": "{\"key\":\"bosmod.near/post/comment\",\"value\":{\"path\":\"badaccount/post/comment\",\"blockHeight\":\"95781851\",\"label\":\"moderate\"}}"
>     }
>   }
> }
> ```

With bos-loader load at https://test.near.org/<ACCOUNT>/widget/Moderation.Moderator?&tab=moderated_posts

![Screenshot 2023-10-03 at 6 45 12 PM](https://github.com/near/near-discovery-components/assets/671506/3042c539-edf8-4748-a1f8-1a63d2994ea1)


