### PR TITLE
Fix the View post link for a liked post

### DIFF
--- a/src/NearOrg/Notifications/Notification.jsx
+++ b/src/NearOrg/Notifications/Notification.jsx
@@ -139,7 +139,8 @@ const profileUrl = `#/${REPL_ACCOUNT}/widget/ProfilePage?accountId=${accountId}`
 let postUrl = "";
 
 if (type !== "custom") {
-  postUrl = `#/${REPL_ACCOUNT}/widget/PostPage?accountId=${accountId}&${urlBlockHeight}=${blockHeight}`;
+  const pathAccount =  path.split('/')[0];
+  postUrl = `#/${REPL_ACCOUNT}/widget/PostPage?accountId=${pathAccount}&${urlBlockHeight}=${blockHeight}`;
 } else {
   postUrl = `#/${value.widget}?${Object.entries(value.params || {})
     .map(([k, v]) => `${k}=${v}`)


### PR DESCRIPTION
fix: use the accountId from the path of a liked non-custom notification object