### PR TITLE
Prevent custom profiles from trying to load themselves.

### DIFF
--- a/src/ProfilePage.jsx
+++ b/src/ProfilePage.jsx
@@ -1,15 +1,17 @@
 const accountId = props.accountId ?? context.accountId;
+const isCustomProfile = props.isCustomProfile || false;
 if (!accountId) {
   return "No account ID";
 }
 
 // if it exists, render the accountId's custom profile component
-if (Social.getr(`${accountId}/widget/ProfilePage`)) {
+if (!isCustomProfile && Social.getr(`${accountId}/widget/ProfilePage`)) {
   return (
     <Widget
       src={`${accountId}/widget/ProfilePage`}
       props={{
         accountId,
+        isCustomProfile: true,
       }}
     />
   );


### PR DESCRIPTION
The ProfilePage now looks to see if a user has a custom profile. When a user forks ProfilePage to create their custom profile, to start with it will have the custom profile loading code. Users will likely not notice this, causing an infinite loop.

This sets a flag to prevent that loop.