### PR TITLE
393 implement reporting content flow

### DIFF
--- a/src/Posts.jsx
+++ b/src/Posts.jsx
@@ -26,7 +26,7 @@ const queryFollowedAccountsList = () => {
   const graph = Social.keys(`${context.accountId}/graph/follow/*`, "final");
   if (graph !== null) {
     const followedAccounts = Object.keys(
-      graph[context.accountId].graph.follow || {}
+      graph[context.accountId].graph.follow || {},
     );
     State.update({ accountsFollowing: followedAccounts });
   }
@@ -45,48 +45,31 @@ const selectTab = (selectedTab) => {
   loadMorePosts();
 };
 
-let gatewayModeratedUsersRaw = Social.get(
-  `${moderatorAccount}/moderate/users`,
-  "optimistic",
-  {
-    subscribe: true,
-  }
-);
-
+// get the full list of posts that the current user has flagged so
+// they can be hidden
 const selfFlaggedPosts = context.accountId
   ? Social.index("flag", "main", {
       accountId: context.accountId,
     })
   : [];
 
-const selfModeration = context.accountId
-  ? Social.index("moderate", "main", {
-      accountId: context.accountId,
-    })
-  : [];
-
-if (gatewayModeratedUsersRaw === null) {
-  // haven't loaded filter list yet, return early
-  return "";
-}
-
-const gatewayModeratedUsers = gatewayModeratedUsersRaw
-  ? JSON.parse(gatewayModeratedUsersRaw)
-  : [];
-
-// get the full list of posts that the current user has flagged so
-// they can be hidden
-
-// expecting moderation structure for accounts and posts like
+// V2 self moderation data, structure is like:
 // { moderate: {
-//     "account1.near": "block",
+//     "account1.near": "report",
 //     "account2.near": {
-//         "100000123": "spam",
+//         ".post.main": { // slashes are not allowed in keys
+//           "100000123": "spam", // post ids are account/blockHeight
+//         }
 //     },
 //   }
 // }
-function matchesModeration(moderated, item) {
-  let accountFound = moderated[accountId];
+const selfModeration = context.accountId
+  ? Social.getr(`${context.accountId}/moderate`, "optimistic")
+  : [];
+const postsModerationKey = ".post.main";
+const matchesModeration = (moderated, socialDBObjectType, item) => {
+  if (!moderated) return false;
+  const accountFound = moderated[item.account_id];
   if (typeof accountFound === "undefined") {
     return false;
   }
@@ -94,19 +77,18 @@ function matchesModeration(moderated, item) {
     return true;
   }
   // match posts
-  return typeof accountFound[item.block_height] !== "undefined";
-}
+  const posts = accountFound[postsModerationKey];
+  return posts && typeof posts[item.block_height] !== "undefined";
+};
 
 const shouldFilter = (item) => {
   return (
-    gatewayModeratedUsers.includes(item.account_id) ||
     selfFlaggedPosts.find((flagged) => {
       return (
         flagged?.value?.blockHeight === item.block_height &&
         flagged?.value?.path.includes(item.account_id)
       );
-    }) ||
-    matchesModeration(selfModeration, item)
+    }) || matchesModeration(selfModeration, postsModerationKey, item)
   );
 };
 function fetchGraphQL(operationsDoc, operationName, variables) {
@@ -210,10 +192,7 @@ const loadMorePosts = () => {
     state.selectedTab == "following" ? "GetFollowingPosts" : "GetPostsQuery";
   const type = state.selectedTab;
 
-  if (
-    state.selectedTab == "following" &&
-    !state.accountsFollowing
-  ) {
+  if (state.selectedTab == "following" && !state.accountsFollowing) {
     return;
   }
   fetchGraphQL(createQuery(type), queryName, {
@@ -229,13 +208,14 @@ const loadMorePosts = () => {
       if (data) {
         const newPosts = data.dataplatform_near_social_feed_moderated_posts;
         const postsCountLeft =
-          data.dataplatform_near_social_feed_moderated_posts_aggregate.aggregate.count;
+          data.dataplatform_near_social_feed_moderated_posts_aggregate.aggregate
+            .count;
         if (newPosts.length > 0) {
           let filteredPosts = newPosts.filter((i) => !shouldFilter(i));
           filteredPosts = filteredPosts.map((post) => {
             const prevComments = post.comments;
             const filteredComments = prevComments.filter(
-              (comment) => !shouldFilter(comment)
+              (comment) => !shouldFilter(comment),
             );
             post.comments = filteredComments;
             return post;
@@ -265,12 +245,7 @@ if (
   queryFollowedAccountsList();
 }
 
-if (
-  !state.initLoadPostsAll &&
-  selfFlaggedPosts &&
-  selfModeration &&
-  gatewayModeratedUsers
-) {
+if (!state.initLoadPostsAll && selfFlaggedPosts && selfModeration) {
   loadMorePosts();
   State.update({ initLoadPostsAll: true });
 }
@@ -482,7 +457,7 @@ return (
             hasMore,
             loadMorePosts,
             posts: state.posts,
-            showFlagAccountFeature: props.showFlagAccountFeature
+            showFlagAccountFeature: props.showFlagAccountFeature,
           }}
         />
       </FeedWrapper>

--- a/src/Posts.jsx
+++ b/src/Posts.jsx
@@ -189,10 +189,10 @@ query GetFollowingPosts($offset: Int, $limit: Int) {
 
 const loadMorePosts = () => {
   const queryName =
-    state.selectedTab == "following" ? "GetFollowingPosts" : "GetPostsQuery";
+    state.selectedTab === "following" ? "GetFollowingPosts" : "GetPostsQuery";
   const type = state.selectedTab;
 
-  if (state.selectedTab == "following" && !state.accountsFollowing) {
+  if (state.selectedTab === "following" && !state.accountsFollowing) {
     return;
   }
   fetchGraphQL(createQuery(type), queryName, {
@@ -251,7 +251,7 @@ if (!state.initLoadPostsAll && selfFlaggedPosts && selfModeration) {
 }
 
 if (
-  state.initLoadPostsAll == true &&
+  state.initLoadPostsAll === true &&
   !state.initLoadPosts &&
   state.accountsFollowing
 ) {
@@ -421,7 +421,7 @@ return (
             </PillSelect>
           </FilterWrapper>
           <SortContainer>
-            {state.selectedTab == "all" && (
+            {state.selectedTab === "all" && (
               <Sort>
                 <span className="label">Sort by:</span>
                 <Widget

--- a/src/Posts/Menu.jsx
+++ b/src/Posts/Menu.jsx
@@ -78,23 +78,24 @@ return (
   <Widget
     src="near/widget/DIG.DropdownMenu"
     props={{
-      trigger: <i className="ph-bold ph-dots-three-vertical" />,
+      trigger: <i className="ph-bold ph-dots-three" />,
       items: [
         {
+        {
           name: "Hide",
-          iconLeft: "ph ph-eye-slash",
+          iconLeft: "ph-bold ph-eye-slash",
           disabled: !context.accountId || context.accountId === accountId,
           subMenuProps: {
             items: [
               {
                 name: "Hide this Post",
-                iconLeft: "ph ph-eye-slash",
+                iconLeft: "ph-bold ph-eye-slash",
                 onSelect: () =>
                   moderatePost(accountId, blockHeight, "hide", "hidePost"),
               },
               {
                 name: "Mute " + accountId,
-                iconLeft: "ph ph-ear-slash",
+                iconLeft: "ph-bold ph-ear-slash",
                 onSelect: () =>
                   moderateAccount(accountId, "hide", "hideAccount"),
               },
@@ -104,8 +105,8 @@ return (
         {
           name: (
             <>
-              <i className="ph ph-prohibit" style={{ color: "var(--red11)" }} />
-              <span style={{ color: "red" }}>Report</span>
+              <i className="ph-bold ph-warning-octagon" style={{ color: "#D95C4A" }} />
+              <span style={{ color: "#D95C4A" }}>Report</span>
             </>
           ),
           disabled: !context.accountId || context.accountId === accountId,
@@ -113,13 +114,13 @@ return (
             items: [
               {
                 name: "Report this Post",
-                iconLeft: "ph ph-warning-circle",
+                iconLeft: "ph-bold ph-warning-octagon",
                 onSelect: () =>
                   moderatePost(accountId, blockHeight, "report", "reportPost"),
               },
               {
                 name: "Report " + accountId,
-                iconLeft: "ph ph-prohibit",
+                iconLeft: "ph-bold ph-warning-octagon",
                 onSelect: () =>
                   moderateAccount(accountId, "report", "reportAccount"),
               },
@@ -128,7 +129,7 @@ return (
         },
         // {
         //   name: "Edit",
-        //   iconLeft: "ph ph-pencil me-1",
+        //   iconLeft: "ph-bold ph-pencil me-1",
         //   onSelect: parentFunctions.toggleEdit,
         //  },
       ],

--- a/src/Posts/Menu.jsx
+++ b/src/Posts/Menu.jsx
@@ -1,45 +1,137 @@
-const Item = styled.div`
-  padding: 0;
-  .btn {
-    width: 100%;
-    border:0;
-    text-align: left;
-    &:hover,
-    &:focus {
-      background-color: #ECEDEE;
-      text-decoration: none;
-      outline: none;
-    }
+const accountId = props.accountId;
+const blockHeight = props.blockHeight;
+const parentFunctions = props.parentFunctions;
 
-    i {
-      color: #7E868C;
-    }
-
-    span {
-      font-weight: 500;
-    }
+const confirmationMessages = {
+  hidePost: {
+    header: "Post Hidden",
+    detail: "This post will no longer be shown to you.",
+  },
+  hideAccount: {
+    header: "Account Muted",
+    detail: "All posts from this account will be no longer be shown to you.",
+  },
+  reportPost: {
+    header: "Post Reported for Moderation",
+    detail:
+      "The item will no longer be shown to you and will be reviewed. Thanks for helping our Content Moderators.",
+  },
+  reportAccount: {
+    header: "Account Reported for Moderation",
+    detail:
+      "All posts from this account will no longer be shown to you and will be reviewed. Thanks for helping our Content Moderators.",
+  },
+};
+const moderatePost = (account, block, action, messageKey) => {
+  const data = {
+    moderate: {
+      [account]: {
+        ".post.main": {
+          [block]: action,
+        },
+      },
+    },
+  };
+  if (action === "report") {
+    data.index = {
+      moderation: JSON.stringify({
+        key: "reported",
+        value: {
+          path: `${account}/post/main`,
+          blockHeight: block,
+          label: action,
+        },
+      }),
+    };
   }
-`;
+  Social.set(data, {
+    onCommit: () => {
+      parentFunctions.resolveHidePost(confirmationMessages[messageKey]);
+    },
+  });
+};
 
+const moderateAccount = (account, action, message) => {
+  const data = {
+    moderate: {
+      [account]: action,
+    },
+  };
+  if (action === "report") {
+    data.index = {
+      moderation: JSON.stringify({
+        key: "reported",
+        value: {
+          path: account,
+          label: action,
+        },
+      }),
+    };
+  }
+  Social.set(data, {
+    onCommit: () => {
+      alert(message);
+    },
+  });
+};
 return (
-  <div className="dropdown ms-auto">
-    <button
-      className="btn border-0 p-0"
-      type="button"
-      data-bs-toggle="dropdown"
-      aria-expanded="false"
-    >
-      <i className="bi bi-three-dots" />
-    </button>
-    <ul className="dropdown-menu">
-
-      {props.elements.map(e => {
-        return (<li>
-          <Item>
-            {e}
-          </Item>
-        </li>)
-      })}
-    </ul>
-  </div>
-)
+  <Widget
+    src="near/widget/DIG.DropdownMenu"
+    props={{
+      trigger: <i className="ph-bold ph-dots-three-vertical" />,
+      items: [
+        {
+          name: "Hide",
+          iconLeft: "ph ph-eye-slash",
+          disabled: !context.accountId || context.accountId === accountId,
+          subMenuProps: {
+            items: [
+              {
+                name: "Hide this Post",
+                iconLeft: "ph ph-eye-slash",
+                onSelect: () =>
+                  moderatePost(accountId, blockHeight, "hide", "hidePost"),
+              },
+              {
+                name: "Mute " + accountId,
+                iconLeft: "ph ph-ear-slash",
+                onSelect: () =>
+                  moderateAccount(accountId, "hide", "hideAccount"),
+              },
+            ],
+          },
+        },
+        {
+          name: (
+            <>
+              <i className="ph ph-prohibit" style={{ color: "var(--red11)" }} />
+              <span style={{ color: "red" }}>Report</span>
+            </>
+          ),
+          disabled: !context.accountId || context.accountId === accountId,
+          subMenuProps: {
+            items: [
+              {
+                name: "Report this Post",
+                iconLeft: "ph ph-warning-circle",
+                onSelect: () =>
+                  moderatePost(accountId, blockHeight, "report", "reportPost"),
+              },
+              {
+                name: "Report " + accountId,
+                iconLeft: "ph ph-prohibit",
+                onSelect: () =>
+                  moderateAccount(accountId, "report", "reportAccount"),
+              },
+            ],
+          },
+        },
+        // {
+        //   name: "Edit",
+        //   iconLeft: "ph ph-pencil me-1",
+        //   onSelect: parentFunctions.toggleEdit,
+        //  },
+      ],
+    }}
+  />
+);

--- a/src/Posts/Menu.jsx
+++ b/src/Posts/Menu.jsx
@@ -81,7 +81,6 @@ return (
       trigger: <i className="ph-bold ph-dots-three" />,
       items: [
         {
-        {
           name: "Hide",
           iconLeft: "ph-bold ph-eye-slash",
           disabled: !context.accountId || context.accountId === accountId,

--- a/src/Posts/Post.jsx
+++ b/src/Posts/Post.jsx
@@ -10,6 +10,8 @@ const showFlagAccountFeature = props.showFlagAccountFeature;
 
 State.init({
   hasBeenFlagged: false,
+  showFlaggedToast: false,
+  flaggedMessage: { header: "", detail: "" },
   postExists: true,
   comments: props.comments ?? undefined,
   content: JSON.parse(props.content) ?? undefined,
@@ -171,6 +173,14 @@ const CommentWrapper = styled.div`
   }
 `;
 
+const resolveHidePost = (message) => {
+  State.update({
+    hasBeenFlagged: true,
+    showFlaggedToast: true,
+    flaggedMessage: message,
+  });
+};
+
 const renderComment = (a) => {
   return (
     <div key={JSON.stringify(a)}>
@@ -196,12 +206,11 @@ if (state.hasBeenFlagged) {
       src={`${REPL_ACCOUNT}/widget/DIG.Toast`}
       props={{
         type: "info",
-        title: "Flagged for moderation",
-        description:
-          "Thanks for helping our Content Moderators. The item you flagged will be reviewed.",
-        open: state.hasBeenFlagged,
+        title: state.flaggedMessage.header,
+        description: state.flaggedMessage.detail,
+        open: state.showFlaggedToast,
         onOpenChange: () => {
-          State.update({ hasBeenFlagged: false });
+          State.update({ showFlaggedToast: false });
         },
         duration: 5000,
       }}
@@ -246,19 +255,19 @@ return (
           />
         </div>
         <div className="col-1">
-          {false && (
+          <div style={{ position: "absolute", right: 0, top: "2px" }}>
             <Widget
               src="${REPL_ACCOUNT}/widget/Posts.Menu"
               props={{
-                elements: [
-                  <button className={`btn`} onClick={toggleEdit}>
-                    <i className="bi bi-pencil me-1" />
-                    <span>Edit</span>
-                  </button>,
-                ],
+                accountId: accountId,
+                blockHeight: blockHeight,
+                parentFunctions: {
+                  toggleEdit,
+                  resolveHidePost,
+                },
               }}
             />
-          )}
+          </div>
         </div>
       </div>
     </Header>
@@ -325,16 +334,6 @@ return (
             props={{
               postType: "post",
               url: postUrl,
-            }}
-          />
-          <Widget
-            src="${REPL_ACCOUNT}/widget/FlagButton"
-            props={{
-              item,
-              disabled: !context.accountId || context.accountId === accountId,
-              onFlag: () => {
-                State.update({ hasBeenFlagged: true });
-              },
             }}
           />
         </Actions>


### PR DESCRIPTION
This is first portion of the new reporting flow [design](https://www.figma.com/proto/bD7wRz3SLLh0N2EwTFjFEQ/Reporting?type=design&node-id=123-1204&t=Nrz0fJqa8Mti60YN-0&scaling=min-zoom&page-id=1%3A2&starting-point-node-id=114%3A1535)

-  Post menu has hide and report post and account options. 
- Hide Toast without re-showing post.
- Hides and reports are in new moderation data structure.

PR is ready for review it just needs to be merged with other moderation PRs.