### PR TITLE
Render mentions inline

### DIFF
--- a/src/SocialMarkdown.jsx
+++ b/src/SocialMarkdown.jsx
@@ -54,6 +54,7 @@ const Wrapper = styled.div`
 const renderMention =
   props.renderMention ??
   ((accountId) => (
+  <span className="d-inline-flex">
     <Widget
       key={accountId}
       src="${REPL_ACCOUNT}/widget/AccountProfileInline"
@@ -62,6 +63,7 @@ const renderMention =
         hideAvatar: true,
       }}
     />
+  </span>
   ));
 
 return (


### PR DESCRIPTION
See [bug](https://github.com/near/near-discovery-components/issues/402) for screenshot of problem. 

Add span from https://near.social/mob.near/widget/WidgetSource?src=mob.near/widget/SocialMarkdown so mentions are inline. 

Should this instead be applied in the AccountProfileInline component?
Reviewers, feel free to commit a different solution to this branch if this span is not the best solution.