### PR TITLE
fix: sets prod-testnet-deploy to track main branch

### DIFF
--- a/.github/workflows/deploy-prod-testnet.yml
+++ b/.github/workflows/deploy-prod-testnet.yml
@@ -1,7 +1,7 @@
 name: Deploy Widgets to Testnet
 on:
   push:
-    branches: [develop]
+    branches: [main]
 jobs:
   deploy-widgets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In response to [this comment](https://github.com/near/near-discovery-components/pull/107#issuecomment-1764474256)