### PR TITLE
chore: fix alignment issue

### DIFF
--- a/src/NearOrg/Notifications/Notification.jsx
+++ b/src/NearOrg/Notifications/Notification.jsx
@@ -226,10 +226,14 @@ return (
         </a>
         <Text>
           <ProfileOverlay>
-            <a href={!props.onClick && profileUrl}>
-              <Username>{profile.name || accountId.split(".near")[0]}</Username>
-            </a>
-            <Action>{notificationMessage[type]}</Action>
+            <div style={{ "text-align": "center" }}>
+              <a href={!props.onClick && profileUrl}>
+                <Username>
+                  {profile.name || accountId.split(".near")[0]}
+                </Username>
+              </a>
+              <Action>{notificationMessage[type]}</Action>
+            </div>
           </ProfileOverlay>
           {/*<ComponentName>{componentName}</ComponentName>*/}
 


### PR DESCRIPTION
@shelegdmitriy or @calebjacob my fix is probably the sloppiest approach. Would you suggest an alternative?

before: 
<img width="949" alt="Screen Shot 2023-10-16 at 3 54 16 PM" src="https://github.com/near/near-discovery-components/assets/1915116/72c0c5f1-ed77-422f-8f07-cb41ec44311c">


with this PR (ignore the super wide display):
<img width="1421" alt="Screen Shot 2023-10-16 at 3 54 03 PM" src="https://github.com/near/near-discovery-components/assets/1915116/2465e0d7-5849-4db6-85f6-e465d1f10a6f">
