### PR TITLE
feat: Create a shorthand command to run bos-loader

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Store the current working directory
+CURRENT_DIR=$(pwd)
+
+# Check if environment and account were provided as arguments
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <environment> <account>"
+  exit 1
+fi
+
+ENVIRONMENT="$1"
+ACCOUNT="$2"
+
+# Define the path to the replacements JSON file
+REPLACEMENTS_FILE="replacements.${ENVIRONMENT}.json"
+
+# Create a temporary file for editing
+TMP_FILE=$(mktemp)
+
+# Check if the REPL_ACCOUNT line exists and remove it
+if grep -q "REPL_ACCOUNT" "$REPLACEMENTS_FILE"; then
+  echo "Removing REPL_ACCOUNT line from $REPLACEMENTS_FILE"
+  grep -v "REPL_ACCOUNT" "$REPLACEMENTS_FILE" > "$TMP_FILE"
+  mv "$TMP_FILE" "$REPLACEMENTS_FILE"
+else
+  echo "No REPL_ACCOUNT line found in $REPLACEMENTS_FILE"
+fi
+
+# Change the working directory to 'src'
+cd src
+
+# Run the bos-loader command from the 'src' directory
+bos-loader -r "../$REPLACEMENTS_FILE" "$ACCOUNT"
+
+# After bos-loader has finished, return to the previous working directory
+cd "$CURRENT_DIR"

--- a/start.sh
+++ b/start.sh
@@ -3,14 +3,27 @@
 # Store the current working directory
 CURRENT_DIR=$(pwd)
 
+# Set these to your preferred environment and account to enable a shorter start syntax
+# ./startup
+DEFAULT_ACCT=""
+DEFAULT_ENV=""
+
+ENVIRONMENT="${DEFAULT_ENV:-"$1"}"
+ACCOUNT="${DEFAULT_ACCT:-"$2"}"
+
+echo ${ENVIRONMENT}
+echo ${ACCOUNT}
+
 # Check if environment and account were provided as arguments
-if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 <environment> <account>"
+if [[ -z "$ENVIRONMENT" ]]; then
+  echo "Missing ENVIRONMENT"
+  exit 1
+fi
+if [[ -z "$ACCOUNT" ]]; then
+  echo "Missing ACCOUNT"
   exit 1
 fi
 
-ENVIRONMENT="$1"
-ACCOUNT="$2"
 
 # Define the path to the replacements JSON file
 REPLACEMENTS_FILE="replacements.${ENVIRONMENT}.json"


### PR DESCRIPTION
As far as I need to start my local env quite ofter I decided to create a shorthand for starting this project with bos-loader. This code is not really my, I created it using Chart-GPT and it seems to work very well 🙂

To start using it you need to do this once
```
chmod +x start.sh
```

And then from home directory run this command:

```
./start.sh testnet discom.testnet
```

At the end you're still need to revert `replacements.*.json` changes.

Feel free to leave your comments here