### PR TITLE
Fix Featured/Latest Component Tags

### DIFF
--- a/src/ComponentCard.jsx
+++ b/src/ComponentCard.jsx
@@ -7,7 +7,7 @@ const metadata =
   Social.get(`${accountId}/widget/${widgetName}/metadata/**`, "final") ??
   {};
 const tags = props.metadata
-  ? props.metadata.tags
+  ? Object.keys(props.metadata.tags || {})
   : Object.keys(metadata.tags || {});
 
 const Card = styled.div`


### PR DESCRIPTION
Issue was found by @TiffanyGYJ:

<img width="747" alt="Screen Shot 2023-10-23 at 11 15 34 AM" src="https://github.com/near/near-discovery-components/assets/1475067/cf6ff1ad-2055-4fbb-ac50-ae3f6a5a7d56">

With my latest performance changes, we weren't properly parsing `props.metadata.tags` when `props.metadata` is passed in to avoid the extra `Social.get()` call.