### PR TITLE
Needs Moderation interface shows reported accounts posts comments

### DIFF
--- a/src/Moderation/ModeratePosts.jsx
+++ b/src/Moderation/ModeratePosts.jsx
@@ -36,55 +36,58 @@ function unblockPost(accountId, blockHeight) {
   });
 }
 
-const moderatedObjects = context.accountId
+const moderatedObjectsRaw = context.accountId
   ? Social.index("moderate", moderationStream, {
       subscribe: true,
       order: "desc",
-    })?.filter((f) => f.accountId === moderatorAccount)
+    }) ?? []
   : [];
+const moderatedObjects = moderatedObjectsRaw.filter(
+  (f) => f.accountId === moderatorAccount,
+);
 const modifiedModerations = {}; // track update & delete operations
 
 return (
   <>
-    <div className="d-flex flex-row gap-2 mb-5">
-      <span style={{ color: "grey", float: left, paddingRight: "2em" }}>
-        When saving, ensure data is being written to moderator key. You may need
-        to refresh your browser if you used "Pretend to be another account"
-        while on this page
-      </span>
-      <input
-        type="text"
-        value={state.accountInput}
-        onChange={(e) => {
-          State.update({
-            accountInput: e.target.value,
-          });
-        }}
-        placeholder="The account of the post to moderate"
-      />
-      <input
-        type="text"
-        value={state.blockInput}
-        onChange={(e) => {
-          State.update({
-            blockInput: e.target.value,
-          });
-        }}
-        placeholder="The block height of the post to moderate"
-      />
+    {context.accountId && context.accountId === moderatorAccount && (
+      <div className="d-flex flex-row gap-2 mb-5">
+        <span>Manual moderation:</span>
+        <input
+          type="text"
+          value={state.accountInput}
+          onChange={(e) => {
+            State.update({
+              accountInput: e.target.value,
+            });
+          }}
+          placeholder="The account of the post to moderate"
+        />
+        <input
+          type="text"
+          value={state.blockInput}
+          onChange={(e) => {
+            State.update({
+              blockInput: e.target.value,
+            });
+          }}
+          placeholder="The block height of the post to moderate"
+        />
 
-      <CommitButton
-        force
-        data={{
-          index: { moderate: blockPost(state.accountInput, state.blockInput) },
-        }}
-        onCommit={() => {
-          State.update({ accountInput: "", blockInput: "" });
-        }}
-      >
-        Add to filter
-      </CommitButton>
-    </div>
+        <CommitButton
+          force
+          data={{
+            index: {
+              moderate: blockPost(state.accountInput, state.blockInput),
+            },
+          }}
+          onCommit={() => {
+            State.update({ accountInput: "", blockInput: "" });
+          }}
+        >
+          Moderate
+        </CommitButton>
+      </div>
+    )}
     <h3>Moderated (blocked) Posts</h3>
     <table className="table">
       <th>Account</th>
@@ -99,6 +102,9 @@ return (
             }
 
             const account = f.value.path.split("/")[0];
+            if (!account) {
+              return;
+            }
             const block = f.value.blockHeight;
             const key = `${account}@${block}`;
             const mod = modifiedModerations[key];

--- a/src/Moderation/Moderator.jsx
+++ b/src/Moderation/Moderator.jsx
@@ -1,8 +1,6 @@
-const Content = styled.div`
-  .post {
-    padding-left: 0;
-    padding-right: 0;
-  }
+const Instructions = styled.div`
+  width: 70%;
+  color: #555;
 `;
 const Wrapper = styled.div`
   display: grid;
@@ -21,44 +19,48 @@ if (props.tab && props.tab !== activeTab) {
 
 const moderatorAccount = props?.moderatorAccount || "${REPL_MODERATOR}";
 const moderationStream = props.moderationStream || moderatorAccount;
-const group = 'near.org';
+const group = "near.org";
 
 function overview() {
   return (
     <div>
       <h4 style={{ textAlign: "left" }}>Overview</h4>
-      <p>Welcome to Moderation for Group: {group}</p>
-      {context.accountId === moderatorAccount ? (
-        <p>
-          <span style={{ fontWeight: "bold" }}>{moderatorAccount}</span> you are
-          a Moderator of this group.
-        </p>
-      ) : (
-        <>
-          <p>{moderatorAccount} you are NOT a moderator of this group.</p>
-          <p style={{ color: "grey", float: left, paddingRight: "2em" }}>
-            When saving, ensure data is being written to moderator key. You may
-            need to refresh your browser if you used "Pretend to be another
-            account" while on this page
+      <Instructions>
+        <p>Welcome to Moderation for Group: {group}</p>
+        {context.accountId === moderatorAccount ? (
+          <p>
+            <span style={{ fontWeight: "bold" }}>{moderatorAccount}</span> you
+            are a Moderator of this group.
           </p>
-        </>
-      )}
-      <div style={{ paddingLeft: "2em" }}>
+        ) : (
+          <>
+            <p>{moderatorAccount} you are NOT a moderator of this group.</p>
+            <p style={{ color: "grey", float: left, paddingRight: "2em" }}>
+              When saving, ensure data is being written to moderator key. You
+              may need to refresh your browser if you used "Pretend to be
+              another account" while on this page
+            </p>
+          </>
+        )}
+        <div style={{ paddingLeft: "2em" }}>
+          <p>
+            Moderating a post or comment will prevent users other than the
+            posting user from seeing it in near widgets (ones where the path
+            starts with /near/widget).
+          </p>
+          <p>
+            Moderating an account will apply moderation to all posts and
+            comments made by that account.
+          </p>
+        </div>
         <p>
-          Moderating a post will prevent users other than the posting user from
-          seeing it in near widgets (ones where the path starts with
-          /near/widget).
+          The Flagged Feed (in Needs Moderation) is being phased out in favor of
+          the new reporting options and data. While widgets transition, some
+          items may be Flagged instead of Reported. These items can still be
+          reviewed and manually moderated (using the controls in the Previously
+          Moderated section).
         </p>
-        <p>
-          Moderating an account will apply moderation to all posts and comments
-          made by that account.
-        </p>
-      </div>
-      <p>
-        The Flagged Feed (in Needs Moderation) is being phased out in favor of
-        the new reporting options and data. While widgets transition, some items
-        may be Flagged instead of Reported.
-      </p>
+      </Instructions>
     </div>
   );
 }

--- a/src/Moderation/NeedsModeration.jsx
+++ b/src/Moderation/NeedsModeration.jsx
@@ -1,0 +1,305 @@
+const moderatorAccount = props?.moderatorAccount || "${REPL_MODERATOR}";
+const moderationStreamBase = props.moderationStream || moderatorAccount;
+
+const GRAPHQL_ENDPOINT =
+  props.GRAPHQL_ENDPOINT || "https://near-queryapi.api.pagoda.co";
+const LIMIT = 25;
+State.init({
+  items: [],
+  itemCountLeft: 0,
+  loadingState: "none",
+  sort,
+});
+
+const moderationDataFormat = (accountId, path, blockHeight) => {
+  let value = { label: "moderate" };
+  value.path = accountId + (path ? path : "");
+  if (blockHeight) {
+    value.blockHeight = parseInt(blockHeight);
+  }
+  const moderationStream = moderationStreamBase + path;
+  return JSON.stringify({
+    key: moderationStream,
+    value: value,
+  });
+};
+
+const fetchGraphQL = (operationsDoc, operationName, variables) => {
+  return asyncFetch(`${GRAPHQL_ENDPOINT}/v1/graphql`, {
+    method: "POST",
+    headers: { "x-hasura-role": "dataplatform_near" },
+    body: JSON.stringify({
+      query: operationsDoc,
+      variables: variables,
+      operationName: operationName,
+    }),
+  });
+};
+
+const createQuery = () => {
+  let querySortOption = "";
+  let queryFilter = "";
+
+  const indexerQueries = `
+query GetNeedsModeration($offset: Int, $limit: Int) {
+  dataplatform_near_social_feed_needs_moderation(
+      where: {${queryFilter}}
+      order_by: [${querySortOption} { first_report_blockheight: desc }], 
+      offset: $offset, limit: $limit) {
+    account_id
+    block_height
+    moderated_path
+    reporter_count
+    reporter_list
+    block_timestamp
+    content
+    receipt_id
+    first_report_blockheight
+  }
+  dataplatform_near_social_feed_needs_moderation_aggregate {
+    aggregate {
+      count
+    }
+  }
+}
+`;
+  return indexerQueries;
+};
+
+const loadItems = () => {
+  const queryName = "GetNeedsModeration";
+  return fetchGraphQL(createQuery(), queryName, {
+    offset: state.items.length,
+    limit: LIMIT,
+  }).then((result) => {
+    if (result.status === 200 && result.body) {
+      if (result.body.errors) {
+        console.log("error:", result.body.errors);
+        return;
+      }
+      let data = result.body.data;
+      if (data) {
+        const newItems = data.dataplatform_near_social_feed_needs_moderation;
+        const itemsCountLeft =
+          data.dataplatform_near_social_feed_needs_moderation_aggregate
+            .aggregate.count;
+        if (newItems) {
+          State.update({
+            items: [...state.items, ...newItems],
+            itemsCountLeft,
+            loadingState: "loaded",
+          });
+        }
+      }
+    }
+  });
+};
+
+if (!state.loadingState || state.loadingState === "none") {
+  State.update({ loadingState: "loading" });
+  state.loadingState = "loading";
+  loadItems();
+  return <p>Loading...</p>;
+}
+if (state.loadingState === "loaded" && state.items.length === 0) {
+  return <p>✨ No items need moderation 🎉</p>;
+}
+
+const hasMore =
+  state.loadingState === "loaded" && state.itemsCountLeft != state.items.length;
+
+const pathToType = (path) => {
+  switch (path) {
+    case `/post/main`:
+      return "Post";
+    case `/post/comment`:
+      return "Comment";
+    case `/discuss`:
+      return "Discussion";
+    case null:
+      return "Account";
+    default:
+      return "Unhandled Content Type" + path;
+  }
+};
+
+const renderItem = (item) => {
+  const accountId = item.account_id;
+  const blockHeight = item.block_height;
+  const id = `${accountId}_${item.first_report_blockheight ?? blockHeight}`;
+
+  let renderWidget;
+  switch (item.moderated_path) {
+    case `/post/main`:
+      if (item.accounts_liked && item.accounts_liked.length !== 0) {
+        item.accounts_liked = JSON.parse(item.accounts_liked);
+      }
+      renderWidget = (
+        <div className="post" key={item.block_height + "_" + item.account_id}>
+          <Widget
+            src="${REPL_ACCOUNT}/widget/Posts.Post"
+            props={{
+              accountId,
+              blockHeight,
+              blockTimestamp: item.block_timestamp,
+              content: item.content,
+              comments: item.comments,
+              GRAPHQL_ENDPOINT,
+              showFlagAccountFeature: false,
+            }}
+          />
+        </div>
+      );
+      break;
+    case `/post/comment`:
+      renderWidget = (
+        <Widget
+          src={`${REPL_ACCOUNT}/widget/Comments.Comment`}
+          props={{
+            accountId,
+            blockHeight,
+            content: item.content,
+            GRAPHQL_ENDPOINT,
+            blockTimestamp: item.block_timestamp,
+          }}
+        />
+      );
+      break;
+    case `/discuss`:
+      renderWidget = (
+        <Widget
+          src="${REPL_ACCOUNT}/widget/NestedDiscussions.Preview"
+          props={{
+            accountId,
+            blockHeight: item.blockHeight,
+            dbAction: "discuss",
+          }}
+        />
+      );
+      break;
+    case null: // account
+      renderWidget = (
+        <Widget
+          src="${REPL_ACCOUNT}/widget/AccountProfile"
+          props={{
+            accountId,
+            hideAccountId: true,
+          }}
+        />
+      );
+      break;
+    default:
+      console.log("Unknown moderated path", item);
+  }
+
+  const header = (
+    <div key={id} style={{ width: "100%" }}>
+      <div className="row">
+        <div className="col">{pathToType(item.moderated_path)}</div>
+        <div className="col-3">
+          reported by {item.reporter_count} {item.reporter_count > 0 ? "users" : "user"}
+        </div>
+        <div className="col">
+          <Widget
+            src="near/widget/DIG.Tooltip"
+            props={{
+              content: "How long ago this item was first reported",
+              trigger: (
+                <>
+                  <Widget
+                    src="${REPL_MOB_2}/widget/TimeAgo${REPL_TIME_AGO_VERSION}"
+                    props={{
+                      blockHeight:
+                        item.first_report_blockheight ?? item.block_height,
+                    }}
+                  />{" "}
+                  ago
+                </>
+              ),
+            }}
+          />
+        </div>
+        <div className="col-lg-6 text-right">
+          {item.moderated_path != null && (
+            <span>
+              <CommitButton
+                force
+                data={{
+                  index: {
+                    moderate: moderationDataFormat(
+                      accountId,
+                      item.moderated_path,
+                      blockHeight,
+                    ),
+                  },
+                }}
+                onCommit={() => {
+                  console.log(
+                    "moderated",
+                    item.account_id,
+                    item.moderated_path,
+                    item.block_height,
+                  );
+                  // todo hide the item, show toast.
+                }}
+              >
+                Block {pathToType(item.moderated_path)}
+              </CommitButton>
+            </span>
+          )}
+          <span style={{ marginLeft: "30px" }}>
+            <CommitButton
+              force
+              data={{
+                index: {
+                  moderate: moderationDataFormat(accountId),
+                },
+              }}
+              onCommit={() => {
+                console.log(
+                  "moderated",
+                  item.account_id,
+                  item.moderated_path,
+                  item.block_height,
+                );
+                // hide the item, show toast.
+              }}
+            >
+              Moderate Account
+            </CommitButton>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+  return { value: id, header, content: renderWidget };
+};
+
+const renderedItems = state.items.map(renderItem);
+
+return (
+  <InfiniteScroll
+    className="mb-5"
+    pageStart={0}
+    loadMore={loadItems}
+    hasMore={hasMore}
+    loader={
+      <div className="loader">
+        <span
+          className="spinner-grow spinner-grow-sm me-1"
+          role="status"
+          aria-hidden="true"
+        />
+        Loading ...
+      </div>
+    }
+  >
+    <Widget
+      src="near/widget/DIG.Accordion"
+      props={{
+        type: "multiple",
+        items: renderedItems,
+      }}
+    />
+  </InfiniteScroll>
+);

--- a/src/Moderation/Sidebar.jsx
+++ b/src/Moderation/Sidebar.jsx
@@ -1,0 +1,68 @@
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  border-right: 1px solid #eceef0;
+  gap: 24px;
+  width: 240px;
+  height: 100%;
+`;
+
+const Title = styled.h2`
+  font: var(text-l);
+  font-weight: 600;
+`;
+
+const MenuItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  transition: 0.2s all;
+  font-weight: 400;
+  ${(p) =>
+    p.active &&
+    `
+    font-weight: 700;
+  `}
+`;
+
+const Text = styled.span`
+  font: var(--text-s);
+  font-weight: inherit;
+  line-height: 16px;
+`;
+
+const Icon = styled.i`
+  font-size: 24px;
+`;
+
+let { activeTab } = props;
+const menuItems = props.items || [
+  {
+    id: "a",
+    icon: "ph-bold ph-users",
+    label: "Menu Item A",
+  },
+  {
+    id: "b",
+    icon: "ph-bold ph-users",
+    label: "Menu Item B",
+  },
+];
+return (
+  <Wrapper>
+    <Title>{props.title || ""}</Title>
+
+    {menuItems.map((item) => (
+      <MenuItem
+        key={`sidebar-${item.id}`}
+        onClick={() => item.onSelect(item.id)}
+        active={activeTab === item.id}
+      >
+        <Icon className={item.icon} />
+        <Text>{item.name}</Text>
+      </MenuItem>
+    ))}
+  </Wrapper>
+);

--- a/src/Moderation/Sidebar.jsx
+++ b/src/Moderation/Sidebar.jsx
@@ -21,10 +21,15 @@ const MenuItem = styled.div`
   transition: 0.2s all;
   font-weight: 400;
   ${(p) =>
-    p.active &&
-    `
-    font-weight: 700;
-  `}
+    p.active && 
+      `color: var(--violet11);
+       font-weight: 700;`
+  }
+  ${(p) =>
+    p.disabled &&
+  `color: var(--sand8);
+   pointer-events: none;`
+  }
 `;
 
 const Text = styled.span`
@@ -40,12 +45,12 @@ const Icon = styled.i`
 let { activeTab } = props;
 const menuItems = props.items || [
   {
-    id: "a",
+    value: "a",
     icon: "ph-bold ph-users",
     label: "Menu Item A",
   },
   {
-    id: "b",
+    value: "b",
     icon: "ph-bold ph-users",
     label: "Menu Item B",
   },
@@ -56,9 +61,10 @@ return (
 
     {menuItems.map((item) => (
       <MenuItem
-        key={`sidebar-${item.id}`}
-        onClick={() => item.onSelect(item.id)}
-        active={activeTab === item.id}
+        key={`sidebar-${item.value}`}
+        onClick={() => item.onSelect(item.value)}
+        active={activeTab === item.value}
+        disabled={item.disabled}
       >
         <Icon className={item.icon} />
         <Text>{item.name}</Text>

--- a/src/Moderation/Sidebar.jsx
+++ b/src/Moderation/Sidebar.jsx
@@ -13,7 +13,8 @@ const Title = styled.h2`
   font-weight: 600;
 `;
 
-const MenuItem = styled.div`
+const MenuItem = styled.button`
+  all: unset;
   display: flex;
   align-items: center;
   gap: 10px;

--- a/src/Moderation/TogglingSetButton.jsx
+++ b/src/Moderation/TogglingSetButton.jsx
@@ -1,0 +1,72 @@
+const data = props.data;
+const title = props.title;
+const onCommit = props.onCommit;
+const onCancel = props.onCancel;
+const isSet = props.isSet ?? false;
+
+if (!data || !title) {
+  return "";
+}
+
+State.init({
+  loading: false,
+  isSetOptimistic: isSet,
+});
+
+const buttonClick = () => {
+  if (state.loading) {
+    return;
+  }
+
+  State.update({
+    loading: true,
+    isSetOptimistic: !isSet,
+  });
+
+  Social.set(data, {
+    force: true,
+    onCommit: () => {
+      State.update({ loading: false, isSet: !isSet });
+      onCommit();
+    },
+    onCancel: () => {
+      State.update({
+        loading: false,
+        isSetOptimistic: !state.isSetOptimistic,
+      });
+      onCancel();
+    },
+  });
+};
+
+const renderButton = () => (
+  <Widget
+    src="near/widget/DIG.Button"
+    props={{
+      label: title,
+      disabled: !context.accountId || state.loading,
+      onClick: buttonClick,
+      iconLeft: state.loading ? "bi-arrow-clockwise" : props.iconLeft,
+      iconRight: state.loading ? "" : props.iconRight,
+      variant: props.variant ?? "secondary",
+      fill: props.fill ?? "solid",
+      size: props.size ?? "small",
+    }}
+  />
+);
+
+if (props.tooltip) {
+  return (
+    <Widget
+      src="near/widget/DIG.Tooltip"
+      props={{
+        content: (
+          <span style={{ whiteSpace: "pre-line" }}>{props.tooltip}</span>
+        ),
+        trigger: renderButton(),
+      }}
+    />
+  );
+} else {
+  return renderButton();
+}


### PR DESCRIPTION
Note, if you test this locally, it only works against `mainnet` due to the dependency on QueryApi. To fully test end to end with a user other than `bosmod.near` reach out to Gabe.

## New Features
Moderator
 * Moderator interface has sidebar for Overview, Needs Moderation, Previously Moderated.
 * Previously Moderated interface allows unmoderation of content and manual moderation.
 * Needs Moderation interface allows moderators to work with feed of reported, not yet moderated content.

Needs Moderation
 * Lists Reported Accounts, Posts, Comments in one feed, grouped by each reported item.
 * Content is hidden until expanded. Meta info in header and header tooltips.
 * Posts and Comments can be individually blocked or whole account can be moderated.
![Screenshot 2023-10-24 at 12 52 33 PM](https://github.com/near/near-discovery-components/assets/671506/b5ffc11e-3ddd-4777-98ea-66fd4858511f)
 * Expanded content shows account, post, or comment
![Screenshot 2023-10-24 at 12 55 32 PM](https://github.com/near/near-discovery-components/assets/671506/37687f59-eed6-4462-8249-80a219c8908a)
 * Moderated content gets local 'Moderated' message until list is reloaded.
![Screenshot 2023-10-24 at 12 58 24 PM](https://github.com/near/near-discovery-components/assets/671506/92575c6c-1754-455d-9420-66a0a2baa0a3)

