### PR TITLE
Fixed CSS in notification profile picture

### DIFF
--- a/src/NearOrg/Notifications/Notification.jsx
+++ b/src/NearOrg/Notifications/Notification.jsx
@@ -1,4 +1,4 @@
-const Notification = styled.div`
+const Notification = styled.a`
   display: flex;
   padding: 16px 24px 16px 16px;
   align-items: flex-start;
@@ -7,6 +7,7 @@ const Notification = styled.div`
 
   &:hover {
     background: var(--sand-light-2, #f9f9f8);
+    text-decoration: none;
 
     & i {
       color: #604cc8;
@@ -211,7 +212,7 @@ const iconType = {
 };
 
 return (
-  <Notification className="notification-item">
+  <Notification className="notification-item" href={postUrl}>
     <Icon>{iconType[type]}</Icon>
     <Content>
       <Left>

--- a/src/NearOrg/Notifications/Notification.jsx
+++ b/src/NearOrg/Notifications/Notification.jsx
@@ -116,6 +116,9 @@ const Desc = styled.span`
 
 const Left = styled.div`
   flex-grow: 1;
+  & a {
+    display: inline-block;
+  }
 `;
 
 const Right = styled.div``;

--- a/src/NearOrg/Notifications/Notification.jsx
+++ b/src/NearOrg/Notifications/Notification.jsx
@@ -1,4 +1,4 @@
-const Notification = styled.a`
+const Notification = styled.div`
   display: flex;
   padding: 16px 24px 16px 16px;
   align-items: flex-start;
@@ -7,7 +7,6 @@ const Notification = styled.a`
 
   &:hover {
     background: var(--sand-light-2, #f9f9f8);
-    text-decoration: none;
 
     & i {
       color: #604cc8;
@@ -212,7 +211,7 @@ const iconType = {
 };
 
 return (
-  <Notification className="notification-item" href={postUrl}>
+  <Notification className="notification-item">
     <Icon>{iconType[type]}</Icon>
     <Content>
       <Left>


### PR DESCRIPTION
Fixes https://github.com/near/near-discovery/issues/584.

The issue has been raised due to the problem of the whitespace within the notification. Instead of directing to the content, it redirects to the user's profile. However the whitespace in notification it is not clickable and the reason the issue is happening it's because the width of profile picture in notification it's very long.
 
Take a look a the picture below:
![image](https://github.com/near/near-discovery-components/assets/95851348/c8003808-052a-41c7-a8ec-55073d06a527)

In the current pull request, I have made some CSS changes to address this issue.
After further investigations we decided not to include clickable whitespace functionality because of the different types of notifications.