### PR TITLE
Activity feed moved deprecation notices

### DIFF
--- a/src/ActivityPageFeed.jsx
+++ b/src/ActivityPageFeed.jsx
@@ -1,0 +1,1 @@
+return "This component is deprecated, it has moved to {REPL_ACCOUNT}/widget/ActivityFeeds.DetermineActivityFeed"

--- a/src/ActivityPageFeed.jsx
+++ b/src/ActivityPageFeed.jsx
@@ -1,1 +1,1 @@
-return "This component is deprecated, it has moved to {REPL_ACCOUNT}/widget/ActivityFeeds.DetermineActivityFeed"
+return "This component is deprecated, it has moved to ${REPL_ACCOUNT}/widget/ActivityFeeds.DetermineActivityFeed"

--- a/src/Posts.jsx
+++ b/src/Posts.jsx
@@ -1,0 +1,1 @@
+return "This component is deprecated, it has moved to {REPL_ACCOUNT}/widget/ActivityFeeds.PostsFeedControls"

--- a/src/Posts.jsx
+++ b/src/Posts.jsx
@@ -1,1 +1,1 @@
-return "This component is deprecated, it has moved to {REPL_ACCOUNT}/widget/ActivityFeeds.PostsFeedControls"
+return "This component is deprecated, it has moved to ${REPL_ACCOUNT}/widget/ActivityFeeds.PostsFeedControls"


### PR DESCRIPTION
Notices that ActivityPageFeed and Posts have moved and that the old component location is deprecated.

src/Feed.jsx and src/Feed/Post.jsx (also removed in [4e3f92](https://github.com/near/near-discovery-components/commit/4e3f9278badf06a6c753dc3d5e9965a2f08e2f8d)) looked out of date enough that it's not worth adding deprecation notices for them.