### PR TITLE
Update terms and privacy

### DIFF
--- a/src/GatewayWrapper.jsx
+++ b/src/GatewayWrapper.jsx
@@ -2,15 +2,13 @@ let {
   targetComponent,
   targetProps,
   logOut,
-  tosDomainName,
-  termsCid,
-  privacyCid,
+  termsDomainName,
+  privacyDomainName,
   recordToC
 } = props;
 
-tosDomainName = tosDomainName ?? "https://near.infura-ipfs.io";
-termsCid = termsCid ?? "QmaE4P6fn2VSTgAJ4gdEmAh7Ywiw9J3TT8aRjMaFLdoDPX";
-privacyCid = privacyCid ?? "QmRiu67GedetzBMwKMfJkrKnFNDSs8KSUDPKEgXKN2hVqU";
+termsDomainName = termsDomainName ?? "https://near.infura-ipfs.io/ipfs/QmaE4P6fn2VSTgAJ4gdEmAh7Ywiw9J3TT8aRjMaFLdoDPX";
+privacyDomainName = privacyDomainName ?? "https://near.infura-ipfs.io/ipfs/QmRiu67GedetzBMwKMfJkrKnFNDSs8KSUDPKEgXKN2hVqU";
 
 const tosName = props.tosName ?? "${REPL_ACCOUNT}/widget/TosContent";
 
@@ -21,9 +19,8 @@ return (
       src="${REPL_ACCOUNT}/widget/TosCheck"
       props={{
         logOut,
-        tosDomainName,
-        termsCid,
-        privacyCid,
+        termsDomainName,
+        privacyDomainName,
         tosName,
         recordToC
       }}

--- a/src/GatewayWrapper.jsx
+++ b/src/GatewayWrapper.jsx
@@ -1,4 +1,17 @@
-const { targetComponent, targetProps, logOut, recordToC } = props;
+let {
+  targetComponent,
+  targetProps,
+  logOut,
+  tosDomainName,
+  termsCid,
+  privacyCid,
+  recordToC
+} = props;
+
+tosDomainName = tosDomainName ?? "https://near.infura-ipfs.io";
+termsCid = termsCid ?? "QmaE4P6fn2VSTgAJ4gdEmAh7Ywiw9J3TT8aRjMaFLdoDPX";
+privacyCid = privacyCid ?? "QmRiu67GedetzBMwKMfJkrKnFNDSs8KSUDPKEgXKN2hVqU";
+
 const tosName = props.tosName ?? "${REPL_ACCOUNT}/widget/TosContent";
 
 return (
@@ -6,7 +19,14 @@ return (
     <Widget
       key="wrapper-tos-check"
       src="${REPL_ACCOUNT}/widget/TosCheck"
-      props={{ logOut, tosName, recordToC }}
+      props={{
+        logOut,
+        tosDomainName,
+        termsCid,
+        privacyCid,
+        tosName,
+        recordToC
+      }}
     />
 
     <Widget key="wrapper-target" src={targetComponent} props={targetProps} />

--- a/src/GatewayWrapper.jsx
+++ b/src/GatewayWrapper.jsx
@@ -7,9 +7,6 @@ let {
   recordToC
 } = props;
 
-termsDomainName = termsDomainName ?? "https://near.infura-ipfs.io/ipfs/QmaE4P6fn2VSTgAJ4gdEmAh7Ywiw9J3TT8aRjMaFLdoDPX";
-privacyDomainName = privacyDomainName ?? "https://near.infura-ipfs.io/ipfs/QmRiu67GedetzBMwKMfJkrKnFNDSs8KSUDPKEgXKN2hVqU";
-
 const tosName = props.tosName ?? "${REPL_ACCOUNT}/widget/TosContent";
 
 return (

--- a/src/NearOrg/PrivacyPage.jsx
+++ b/src/NearOrg/PrivacyPage.jsx
@@ -1,0 +1,37 @@
+let { privacyDomainName, compact } = props;
+
+compact = compact ?? false;
+
+const [privacy, setPrivacy] = useState(null);
+
+const fetchPrivacy = useCallback(() => {
+  try {
+    asyncFetch(privacyDomainName).then((res) => {
+      setPrivacy(res.body);
+    });
+  } catch (error) {
+    console.error(`Error on fetching privacy from ${privacyDomainName}: `, error);
+  }
+}, [privacyDomainName]);
+
+useEffect(() => {
+  fetchPrivacy();
+}, [privacyDomainName]);
+
+if (!privacy) {
+  return <div>Loading...</div>;
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${(p) => !p.compact && "18px"};
+  padding-bottom: ${(p) => !p.compact && "48px"};
+  padding-top: ${(p) => !p.compact && "48px"};
+`;
+
+return (
+  <Wrapper className="container-xl" compact={compact}>
+    <Markdown text={privacy} />
+  </Wrapper>
+);

--- a/src/NearOrg/TermsPage.jsx
+++ b/src/NearOrg/TermsPage.jsx
@@ -1,0 +1,37 @@
+let { termsDomainName, compact } = props;
+
+compact = compact ?? false;
+
+const [terms, setTerms] = useState(null);
+
+const fetchTerms = useCallback(() => {
+  try {
+    asyncFetch(termsDomainName).then((res) => {
+      setTerms(res.body);
+    });
+  } catch (error) {
+    console.error(`Error on fetching terms from ${termsDomainName}: `, error);
+  }
+}, [termsDomainName]);
+
+useEffect(() => {
+  fetchTerms();
+}, [termsDomainName]);
+
+if (!terms) {
+  return <div>Loading...</div>;
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${(p) => !p.compact && "18px"};
+  padding-bottom: ${(p) => !p.compact && "48px"};
+  padding-top: ${(p) => !p.compact && "48px"};
+`;
+
+return (
+  <Wrapper className="container-xl" compact={compact}>
+    <Markdown text={terms} />
+  </Wrapper>
+);

--- a/src/TosCheck.jsx
+++ b/src/TosCheck.jsx
@@ -1,11 +1,15 @@
-const { tosName, logOut, recordToC } = props;
-const acceptanceKey = tosName; // may change
+const {
+  tosDomainName,
+  termsCid,
+  privacyCid,
+  tosName,
+  logOut,
+  recordToC,
+} = props;
 
-State.init({
-  hasCommittedAcceptance: false,
-  agreeIsChecked: false,
-  expand: false,
-});
+const acceptanceKey = tosName; // may change
+const [agreeIsChecked, setAgreeIsChecked] = useState(false);
+const [hasCommittedAcceptance, setCommittedAcceptance] = useState(false);
 
 // find all instances of the user agreeing to some version of the desired TOS
 const agreementsForUser = context.accountId
@@ -29,11 +33,22 @@ const latestTosVersion = tosPath.reduce((acc, curr) => {
 const Backdrop = styled.div`
   height: 100vh;
   width: 100vw;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--blackA3);
+  backdrop-filter: blur(4px);
   position: fixed;
   left: 0;
   top: 0;
   z-index: 1001;
+  animation: overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+
+  @keyframes overlayShow {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
 `;
 
 const Modal = styled.div`
@@ -47,69 +62,29 @@ const Modal = styled.div`
   display: flex;
   row-gap: 1rem;
   flex-direction: column;
+  box-shadow: 0px 4px 8px 0px var(--blackA3), 0px 0px 0px 1px var(--blackA4);
 `;
 
-const ModalContent = styled.div`
+const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 1 min-height 0;
   overflow-y: auto;
 `;
 
-const ModalFooter = styled.div`
+const TosFooter = styled.div`
   display: flex;
   flex-direction: column;
   row-gap: 2rem;
 `;
 
-const AcceptSection = styled.div`
+const TosButtons = styled.div`
   display: flex;
   flex-direction: row;
   column-gap: 1rem;
-
-  .continue-button {
-    background: #59e692;
-    color: #09342e;
-    border-radius: 40px;
-    height: 40px;
-    padding: 0 35px;
-    font-weight: 600;
-    font-size: 14px;
-    border: none;
-    cursor: pointer;
-    transition: background 200ms, opacity 200ms;
-
-    &:hover,
-    &:focus {
-      background: rgb(112 242 164);
-      outline: none;
-    }
-
-    &:disabled {
-      opacity: 0.5;
-      pointer-events: none;
-    }
-  }
-`;
-
-const CheckWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
+  justify-content: space-between;
   align-items: center;
-  color: ${state.agreeIsChecked ? "#26A65A" : "inherit"};
 `;
-
-const CheckButton = styled.button`
-  border: none;
-  --bs-btn-hover-bg: transparent;
-  --bs-btn-active-bg: transparent;
-  --bs-btn-color: ${state.agreeIsChecked ? "#26A65A" : "black"};
-  --bs-btn-hover-color: ${state.agreeIsChecked ? "#26A65A" : "var(--bs-blue)"};
-`;
-
-const expand = (e) => {
-  State.update({ expand: e });
-};
 
 if (
   agreementsForUser.length === 0 ||
@@ -132,12 +107,36 @@ if (
   }
 }
 
+const handleTermsAndPrivacyCheck = useCallback(
+  (value) => {
+    setAgreeIsChecked(value);
+  }, []);
+
+const handleConfirm = useCallback(() => {
+  Social.set(
+    {
+      index: {
+        tosAccept: JSON.stringify({
+          key: acceptanceKey,
+          value: latestTosVersion,
+        }),
+      },
+    },
+    {
+      onCommit: () => {
+        setCommittedAcceptance(true);
+      },
+    }
+  );
+}, []);
+
 // we check for existence of Index results because if no results are found
 // we get an empty array. This means that when the existence check fails
 // we are still loading and we do not want to potentially flash the modal
 // until we know for sure that it should be displayed
+
 const showTos =
-  !state.hasCommittedAcceptance &&
+  !hasCommittedAcceptance &&
   context.accountId &&
   latestTosVersion &&
   agreementsForUser &&
@@ -152,71 +151,59 @@ if (agreementsForUser && recordToC) {
   });
 }
 
+const TosContent = () => (
+  <ContentWrapper>
+    <Widget
+      src={tosName}
+      props={{
+        tosDomainName,
+        termsCid,
+        privacyCid,
+      }}
+    />
+  </ContentWrapper>
+);
+
+const TosActions = () => (
+  <TosFooter>
+    <Widget
+      src="${REPL_ACCOUNT}/widget/DIG.Checkbox"
+      props={{
+        id: "agree-terms-and-privacy",
+        label: "I agree to the Terms of Service and Privacy Policy",
+        checked: agreeIsChecked,
+        onCheckedChange: handleTermsAndPrivacyCheck,
+      }}
+    />
+    <TosButtons>
+      <Widget
+        src="${REPL_ACCOUNT}/widget/DIG.Button"
+        props={{
+          label: "Decline",
+          variant: "secondary",
+          onClick: logOut,
+        }}
+      />
+      <Widget
+        src="${REPL_ACCOUNT}/widget/DIG.Button"
+        props={{
+          label: "Continue",
+          variant: "affirmative",
+          disabled: !agreeIsChecked,
+          onClick: handleConfirm,
+        }}
+      />
+    </TosButtons>
+  </TosFooter>
+);
+
 return (
   <>
     {showTos && (
       <Backdrop className="d-flex">
         <Modal>
-          <ModalContent>
-            <Widget src={tosName} props={expand} />
-          </ModalContent>
-          <ModalFooter>
-            <CheckWrapper>
-              <CheckButton
-                onClick={() => {
-                  State.update({ agreeIsChecked: !state.agreeIsChecked });
-                }}
-                className="btn btn-outline-dark"
-              >
-                <div className="d-flex flex-row align-items-center gap-3">
-                  <i
-                    className={`bi bi-${
-                      state.agreeIsChecked ? "check-square" : "square"
-                    }`}
-                    style={{ fontSize: "1.5rem" }}
-                  />
-                  <span style={{ textAlign: "left" }}>
-                    I agree to the Terms of Service and Privacy Policy
-                  </span>
-                </div>
-              </CheckButton>
-            </CheckWrapper>
-            <AcceptSection>
-              <button
-                className="btn btn-outline-secondary"
-                style={{
-                  flexGrow: 1,
-                  flexBasis: "10rem",
-                  borderRadius: "1.25rem",
-                }}
-                onClick={logOut}
-              >
-                Decline
-              </button>
-              <CommitButton
-                style={{
-                  flexGrow: 1,
-                  flexBasis: "10rem",
-                  borderRadius: "1.25rem",
-                }}
-                className="continue-button"
-                disabled={!state.agreeIsChecked}
-                data={{
-                  index: {
-                    tosAccept: JSON.stringify({
-                      key: acceptanceKey,
-                      value: latestTosVersion,
-                    }),
-                  },
-                }}
-                onCommit={() => {
-                  State.update({ hasCommittedAcceptance: true });
-                }}
-              >
-                Continue
-              </CommitButton>
-            </AcceptSection>
-          </ModalFooter>
+          <TosContent />
+          <TosActions />
         </Modal>
       </Backdrop>
     )}

--- a/src/TosCheck.jsx
+++ b/src/TosCheck.jsx
@@ -1,10 +1,9 @@
 const {
-  tosDomainName,
-  termsCid,
-  privacyCid,
+  termsDomainName,
+  privacyDomainName,
   tosName,
   logOut,
-  recordToC,
+  recordToC
 } = props;
 
 const acceptanceKey = tosName; // may change
@@ -107,10 +106,9 @@ if (
   }
 }
 
-const handleTermsAndPrivacyCheck = useCallback(
-  (value) => {
-    setAgreeIsChecked(value);
-  }, []);
+const handleTermsAndPrivacyCheck = useCallback((value) => {
+  setAgreeIsChecked(value);
+}, []);
 
 const handleConfirm = useCallback(() => {
   Social.set(
@@ -156,9 +154,8 @@ const TosContent = () => (
     <Widget
       src={tosName}
       props={{
-        tosDomainName,
-        termsCid,
-        privacyCid,
+        termsDomainName,
+        privacyDomainName,
       }}
     />
   </ContentWrapper>

--- a/src/TosContent.jsx
+++ b/src/TosContent.jsx
@@ -1,33 +1,6 @@
-let { tosDomainName, termsCid, privacyCid, expand } = props;
+let { termsDomainName, privacyDomainName, compact } = props;
 
-const [terms, setTerms] = useState(null);
-const [privacy, setPrivacy] = useState(null);
 const [viewMode, setViewMode] = useState("default"); // one of: "default", "terms", "privacy", "community"
-
-const fetchTerms = useCallback(() => {
-  try {
-    asyncFetch(`${tosDomainName}/ipfs/${termsCid}`).then((res) => {
-      setTerms(res.body);
-    });
-  } catch (error) {
-    console.error(`Error on fetching terms from ${tosDomainName}: `, error);
-  }
-}, [tosDomainName, termsCid]);
-
-const fetchPrivacy = useCallback(() => {
-  try {
-    asyncFetch(`${tosDomainName}/ipfs/${privacyCid}`).then((res) => {
-      setPrivacy(res.body);
-    });
-  } catch (error) {
-    console.error(`Error on fetching privacy from ${tosDomainName}: `, error);
-  }
-}, [tosDomainName, privacyCid]);
-
-useEffect(() => {
-  fetchTerms();
-  fetchPrivacy();
-}, [tosDomainName, termsCid, privacyCid]);
 
 const Wrapper = styled.div`
   display: flex;
@@ -61,7 +34,7 @@ const DocBox = styled.div`
   border-radius: 0.75rem;
   padding: 1rem;
   cursor: pointer;
-  transition: all .2s ease-in-out;
+  transition: all 0.2s ease-in-out;
 
   &:hover {
     color: var(--violet8);
@@ -90,7 +63,7 @@ const DocSummary = styled.span`
 const Arrow = styled.i`
   color: var(--green11);
   font-size: 1.25rem;
-  transition: all .2s ease-in-out;
+  transition: all 0.2s ease-in-out;
 
   ${DocBox}:hover & {
     color: var(--violet8);
@@ -119,21 +92,19 @@ const DocumentSelector = ({ name, title, description }) => (
       {title}
       <Arrow className="ph ph-arrow-right" />
     </DocTitle>
-    <DocSummary>
-      {description}
-    </DocSummary>
+    <DocSummary>{description}</DocSummary>
   </DocBox>
 );
 
 const ViewDocument = () => {
-  if (viewMode === "default") return <></>
+  if (viewMode === "default") return <></>;
   return (
     <>
       <BackWrapper>
         <Widget
           src="${REPL_ACCOUNT}/widget/DIG.Chip"
           props={{
-            label: 'Back',
+            label: "Back",
             iconLeft: "ph ph-arrow-left",
             onClick: () => setViewMode("default"),
           }}
@@ -141,16 +112,22 @@ const ViewDocument = () => {
       </BackWrapper>
       {viewMode === "terms" && (
         <DocContent>
-          {terms ? <Markdown text={terms} /> : <p>Loading...</p>}
+          <Widget
+            src={`${REPL_ACCOUNT}/widget/NearOrg.TermsPage`}
+            props={{ termsDomainName, compact }}
+          />
         </DocContent>
       )}
       {viewMode === "privacy" && (
         <DocContent>
-          {privacy ? <Markdown text={privacy} /> : <p>Loading...</p>}
+          <Widget
+            src={`${REPL_ACCOUNT}/widget/NearOrg.PrivacyPage`}
+            props={{ privacyDomainName, compact }}
+          />
         </DocContent>
       )}
     </>
-  )
+  );
 };
 
 return (


### PR DESCRIPTION
Relates to [#525](https://github.com/near/near-discovery/issues/525), [#526](https://github.com/near/near-discovery/issues/526)

Closes [#727](https://github.com/near/near-discovery/issues/727)

This PR introduces new terms and privacy docs which stores in new infura account. All the credentials could be found in 1Password.

Also this PR includes:
- style changes for ToS modal to be aligned with other gateway components;
- new terms and privacy pages;