### PR TITLE
feat() Routing /people to PeoplePage trending tab, if no props are set

### DIFF
--- a/src/PeoplePage.jsx
+++ b/src/PeoplePage.jsx
@@ -7,7 +7,7 @@ const fromContext = props;
 
 State.init({
   currentPage: 0,
-  selectedTab: props.tab || "everyone",
+  selectedTab: props.tab ?? "trending",
 });
 
 if (props.tab && props.tab !== state.selectedTab) {


### PR DESCRIPTION
Routing for link /people in Header > Ecosystem > People should redirect to PeoplePage?tab=trending