### PR TITLE
Use ActivityFeed on ProfilePage

### DIFF
--- a/src/ActivityFeeds/DetermineActivityFeed.jsx
+++ b/src/ActivityFeeds/DetermineActivityFeed.jsx
@@ -71,7 +71,6 @@ return (
         src={`${REPL_ACCOUNT}/widget/ActivityFeeds.PostsFeedControls`}
         props={{
           GRAPHQL_ENDPOINT,
-          accountsFollowing,
           showFlagAccountFeature: true,
         }}
       />

--- a/src/ProfilePage.jsx
+++ b/src/ProfilePage.jsx
@@ -163,7 +163,13 @@ if (profile === null) {
   return "Loading";
 }
 
-return (
+const feeds = ["all"];
+if(accountId !== context.accountId) {
+  feeds.push("mutual");
+}
+
+
+  return (
   <Wrapper>
     <BackgroundImage>
       {profile.backgroundImage && (
@@ -253,8 +259,8 @@ return (
             )}
 
             <Widget
-              src="${REPL_ACCOUNT}/widget/v1.Feed"
-              props={{ accounts: [accountId] }}
+              src="${REPL_ACCOUNT}/widget/ActivityFeeds.PostsFeedControls"
+              props={{ filteredAccountIds: accountId, showCompose: false, feeds: feeds}}
             />
           </>
         )}


### PR DESCRIPTION
Main features
* By using the main Activity feed, standard moderation and self-moderation is applied to the content.
* Add account filter to Activity feed 
* Use Activity Feed on Profile Page with account filter
* Add Mutual Activity feed for use on profile page instead of Following Feed

Small adjustments
* Only show feed selector if there is more than one.
* Show sort selector for all feeds
* property determines whether to show Compose Post area.

This is a screenshot of the Overview portion of a user's profile (when viewed by a different user). 
![Screenshot 2023-10-31 at 11 19 27 AM](https://github.com/near/near-discovery-components/assets/671506/ce864576-40a1-4504-8a13-9b0023591052)
