### PR TITLE
Replace flag account with hide/report menu with only account options

### DIFF
--- a/src/Posts/Menu.jsx
+++ b/src/Posts/Menu.jsx
@@ -94,67 +94,78 @@ const moderateAccount = (account, action, messageKey) => {
     }
   });
 };
+
+const buildMenu = (accountId, blockHeight, parentFunctions) => {
+  const hideSubmenu = [
+    {
+      name: "Mute " + accountId,
+      iconLeft: "ph-bold ph-ear-slash",
+      onSelect: () =>
+          moderateAccount(accountId, "hide", "hideAccount"),
+    }
+  ];
+
+  const reportSubmenu = [
+    {
+      name: "Report " + accountId,
+      iconLeft: "ph-bold ph-warning-octagon",
+      onSelect: () =>
+          moderateAccount(accountId, "report", "reportAccount"),
+    },
+  ];
+
+  if(blockHeight) {
+    hideSubmenu.unshift({
+      name: "Hide this " + capitalizedContentType,
+      iconLeft: "ph-bold ph-eye-slash",
+      onSelect: () =>
+          moderateItem(accountId, blockHeight, "hide", "hideItem"),
+    });
+    reportSubmenu.unshift({
+      name: "Report this " + capitalizedContentType,
+      iconLeft: "ph-bold ph-warning-octagon",
+      onSelect: () =>
+          moderateItem(accountId, blockHeight, "report", "reportItem"),
+    });
+  }
+  return [
+    {
+      name: "Hide",
+      iconLeft: "ph-bold ph-eye-slash",
+      disabled: !context.accountId || context.accountId === accountId,
+      subMenuProps: {
+        items: hideSubmenu,
+      },
+    },
+    {
+      name: (
+          <>
+            <i
+                className="ph-bold ph-warning-octagon"
+                style={{ color: "#D95C4A" }}
+            />
+            <span style={{ color: "#D95C4A" }}>Report</span>
+          </>
+      ),
+      disabled: !context.accountId || context.accountId === accountId,
+      subMenuProps: {
+        items: reportSubmenu
+      },
+    },
+    // {
+    //   name: "Edit",
+    //   iconLeft: "ph-bold ph-pencil me-1",
+    //   onSelect: parentFunctions.toggleEdit,
+    //  },
+  ]
+}
+
 return (
   <Widget
     src="${REPL_ACCOUNT}/widget/DIG.DropdownMenu"
     props={{
       trigger: <i className="ph-bold ph-dots-three" />,
-      items: [
-        {
-          name: "Hide",
-          iconLeft: "ph-bold ph-eye-slash",
-          disabled: !context.accountId || context.accountId === accountId,
-          subMenuProps: {
-            items: [
-              {
-                name: "Hide this " + capitalizedContentType,
-                iconLeft: "ph-bold ph-eye-slash",
-                onSelect: () =>
-                  moderateItem(accountId, blockHeight, "hide", "hideItem"),
-              },
-              {
-                name: "Mute " + accountId,
-                iconLeft: "ph-bold ph-ear-slash",
-                onSelect: () =>
-                  moderateAccount(accountId, "hide", "hideAccount"),
-              },
-            ],
-          },
-        },
-        {
-          name: (
-            <>
-              <i
-                className="ph-bold ph-warning-octagon"
-                style={{ color: "#D95C4A" }}
-              />
-              <span style={{ color: "#D95C4A" }}>Report</span>
-            </>
-          ),
-          disabled: !context.accountId || context.accountId === accountId,
-          subMenuProps: {
-            items: [
-              {
-                name: "Report this " + capitalizedContentType,
-                iconLeft: "ph-bold ph-warning-octagon",
-                onSelect: () =>
-                  moderateItem(accountId, blockHeight, "report", "reportItem"),
-              },
-              {
-                name: "Report " + accountId,
-                iconLeft: "ph-bold ph-warning-octagon",
-                onSelect: () =>
-                  moderateAccount(accountId, "report", "reportAccount"),
-              },
-            ],
-          },
-        },
-        // {
-        //   name: "Edit",
-        //   iconLeft: "ph-bold ph-pencil me-1",
-        //   onSelect: parentFunctions.toggleEdit,
-        //  },
-      ],
+      items: buildMenu(accountId, blockHeight, parentFunctions),
     }}
   />
 );

--- a/src/ProfilePage/Sidebar.jsx
+++ b/src/ProfilePage/Sidebar.jsx
@@ -48,6 +48,28 @@ const contentModerationItem = {
   reportedBy: context.accountId,
 };
 
+const optimisticallyHideItem = (message) => {
+  State.update({
+    hasBeenFlaggedOptimistic: true,
+    showToast: true,
+    flaggedMessage: message,
+  });
+};
+const resolveHideItem = (message) => {
+  State.update({
+    hasBeenFlagged: true,
+    showToast: true,
+    flaggedMessage: message,
+  });
+};
+const cancelHideItem = () => {
+  State.update({
+    hasBeenFlaggedOptimistic: false,
+    showToast: false,
+    flaggedMessage: { header: "", detail: "" }
+  });
+}
+
 const Wrapper = styled.div`
   display: grid;
   gap: 40px;
@@ -242,34 +264,35 @@ return (
 
           {accountFollowsYou && <TextBadge>Follows You</TextBadge>}
         </div>
-        {accountId !== context.accountId && (
-          <Widget
-            src={`${REPL_ACCOUNT}/widget/DIG.Toast`}
-            props={{
-              type: "info",
-              title: "Flagged for moderation",
-              description:
-                "Thanks for helping our Content Moderators. The item you flagged will be reviewed.",
-              open: state.hasBeenFlagged,
-              onOpenChange: () => {
-                State.update({ hasBeenFlagged: false });
-              },
-              duration: 5000,
-              trigger: (
-                <div className="d-inline-block ms-auto">
-                  <Widget
-                    src="${REPL_ACCOUNT}/widget/FlagButton"
-                    props={{
-                      item: contentModerationItem,
-                      onFlag: () => {
-                        State.update({ hasBeenFlagged: true });
-                      },
-                    }}
-                  />
-                </div>
-              ),
-            }}
-          />
+        {accountId !== context.accountId &&
+          (<>
+            {state.showToast && (
+                <Widget
+                  src={`${REPL_ACCOUNT}/widget/DIG.Toast`}
+                  props={{
+                    type: "info",
+                    title: state.flaggedMessage.header,
+                    description: state.flaggedMessage.detail,
+                    open: state.showToast,
+                    onOpenChange: () => {
+                      State.update({showToast: false});
+                    },
+                    duration: 5000,
+                  }}
+                />
+              )}
+              <Widget
+                src="${REPL_ACCOUNT}/widget/Posts.Menu"
+                props={{
+                  accountId: accountId,
+                  parentFunctions: {
+                    optimisticallyHideItem,
+                    resolveHideItem,
+                    cancelHideItem,
+                  },
+                }}
+              />
+            </>
         )}
       </div>
 


### PR DESCRIPTION
The hide/report menu can be the entry point for all self-moderation actions. This updates it to show only account actions if no blockheight is passed. On the ProfilePage flag account is replaced with the menu.