### PR TITLE
Fix several small Moderator interface bugs

### DIFF
--- a/indexers/moderation/moderation.js
+++ b/indexers/moderation/moderation.js
@@ -136,7 +136,7 @@ async function getBlock(block: Block) {
             label,
           },
         };
-        context.graphql(
+        await context.graphql(
           `mutation insertReport($report: dataplatform_near_moderation_moderation_reporting_insert_input!) {
                         insert_dataplatform_near_moderation_moderation_reporting_one( object: $report
                         ) { group account_id moderated_account_id moderated_path moderated_blockheight label }

--- a/indexers/moderation/moderation.sql
+++ b/indexers/moderation/moderation.sql
@@ -45,8 +45,10 @@ CREATE INDEX
 CREATE VIEW dataplatform_near_moderation.unmoderated_reports as
 SELECT min(report_blockheight) as first_report_blockheight, count(account_id) as reporter_count,
        array(select account_id from dataplatform_near_moderation.moderation_reporting rl
-             where rl.moderated_account_id = r.moderated_account_id
-               and rl.moderated_path = r.moderated_path and rl.moderated_blockheight = r.moderated_blockheight limit 5) as reporter_list,
+             WHERE ((rl.moderated_account_id = r.moderated_account_id)
+                        AND ((rl.moderated_path IS NULL) OR
+                             ((rl.moderated_path = r.moderated_path) AND (rl.moderated_blockheight = r.moderated_blockheight))))
+             limit 5) as reporter_list,
        moderated_account_id, moderated_path, moderated_blockheight,
        mode() within group (order by label) as most_frequent_label --  most prevalent label
 FROM dataplatform_near_moderation.moderation_reporting r
@@ -59,17 +61,17 @@ WHERE NOT EXISTS (
 GROUP by moderated_account_id, moderated_path, moderated_blockheight;
 
 CREATE VIEW dataplatform_near_moderation.needs_moderation as
-SELECT r.most_frequent_label, r.first_report_blockheight, r.reporter_count, r.reporter_list, r.moderated_path, p.account_id, p.block_height, p.block_timestamp, p.receipt_id, p.content
+SELECT r.most_frequent_label, r.first_report_blockheight, r.reporter_count, r.reporter_list, r.moderated_path, p.account_id, p.block_height, p.block_timestamp, 'removed' as receipt_id, p.content
 FROM dataplatform_near_moderation.unmoderated_reports as r
          INNER JOIN dataplatform_near_social_feed.posts p
                     ON p.account_id = r.moderated_account_id AND r.moderated_blockheight = p.block_height AND r.moderated_path = '/post/main'
 UNION
-SELECT r.most_frequent_label, r.first_report_blockheight, r.reporter_count, r.reporter_list, r.moderated_path, c.account_id, c.block_height, c.block_timestamp, c.receipt_id, c.content
+SELECT r.most_frequent_label, r.first_report_blockheight, r.reporter_count, r.reporter_list, r.moderated_path, c.account_id, c.block_height, c.block_timestamp, 'removed' as receipt_id, c.content
 FROM dataplatform_near_moderation.unmoderated_reports as r
          INNER JOIN dataplatform_near_social_feed.comments c
                     ON c.account_id = r.moderated_account_id AND r.moderated_blockheight = c.block_height AND r.moderated_path = '/post/comment'
 UNION
-SELECT r.most_frequent_label, r.first_report_blockheight, r.reporter_count, r.reporter_list, null as moderated_path, moderated_account_id as account_id, null as block_height, null as block_timestamp, null as receipt_id, null as content
+SELECT r.most_frequent_label, r.first_report_blockheight, r.reporter_count, r.reporter_list, null as moderated_path, moderated_account_id as account_id, null as block_height, null as block_timestamp, 'removed' as receipt_id, null as content
 FROM dataplatform_near_moderation.unmoderated_reports as r
 WHERE r.moderated_path is null
 ORDER BY block_height DESC;

--- a/src/Moderation/Moderator.jsx
+++ b/src/Moderation/Moderator.jsx
@@ -34,7 +34,7 @@ function overview() {
           </p>
         ) : (
           <>
-            <p>{moderatorAccount} you are NOT a moderator of this group.</p>
+            <p>{context.accountId} you are NOT a moderator of this group.</p>
             <p style={{ color: "grey", float: left, paddingRight: "2em" }}>
               When saving, ensure data is being written to moderator key. You
               may need to refresh your browser if you used "Pretend to be

--- a/src/Moderation/NeedsModeration.jsx
+++ b/src/Moderation/NeedsModeration.jsx
@@ -1,5 +1,6 @@
 const moderatorAccount = props?.moderatorAccount || "${REPL_MODERATOR}";
 const moderationStreamBase = props.moderationStream || moderatorAccount;
+const isModerator = context.accountId === moderatorAccount;
 
 const GRAPHQL_ENDPOINT =
   props.GRAPHQL_ENDPOINT || "https://near-queryapi.api.pagoda.co";
@@ -18,7 +19,7 @@ const moderationDataFormat = (accountId, path, blockHeight) => {
   if (blockHeight) {
     value.blockHeight = parseInt(blockHeight);
   }
-  const moderationStream = moderationStreamBase + path;
+  const moderationStream = moderationStreamBase + (path ? path : "");
   return JSON.stringify({
     key: moderationStream,
     value: value,
@@ -54,7 +55,6 @@ query GetNeedsModeration($offset: Int, $limit: Int) {
     reporter_list
     block_timestamp
     content
-    receipt_id
     first_report_blockheight
     most_frequent_label
   }
@@ -153,6 +153,7 @@ const renderModeratedRow = (id, item) => {
   return { value: id, header, content: renderWidget };
 };
 
+const disabledMessage = "Button is disabled because you are not a moderator of this group.";
 const blockItemHelperText =
   "to no longer be shown in feeds that obey moderation. \n" +
   "Direct links will show a moderation message. \n" +
@@ -282,12 +283,13 @@ const renderItem = (item) => {
                 src="${REPL_ACCOUNT}/widget/Moderation.TogglingSetButton"
                 props={{
                   title: "Block " + pathToType(item.moderated_path),
+                  disabled: !isModerator,
                   iconLeft: "ph-bold ph-warning-octagon",
                   tooltip:
                     "Cause this " +
                     pathToType(item.moderated_path) +
                     " " +
-                    blockItemHelperText,
+                    blockItemHelperText + (isModerator ? "":  "\n" + disabledMessage),
                   data: {
                     index: {
                       moderate: moderationDataFormat(
@@ -309,8 +311,9 @@ const renderItem = (item) => {
               src="${REPL_ACCOUNT}/widget/Moderation.TogglingSetButton"
               props={{
                 title: "Moderate Account",
+                disabled: !isModerator,
                 iconLeft: "ph-bold ph-prohibit",
-                tooltip: blockAccountHelperText,
+                tooltip: blockAccountHelperText + (isModerator ? "":  "\n" + disabledMessage),
                 variant: "destructive",
                 fill: "outline",
                 data: {

--- a/src/Moderation/TogglingSetButton.jsx
+++ b/src/Moderation/TogglingSetButton.jsx
@@ -3,6 +3,7 @@ const title = props.title;
 const onCommit = props.onCommit;
 const onCancel = props.onCancel;
 const isSet = props.isSet ?? false;
+const disabled = props.disabled ?? false;
 
 if (!data || !title) {
   return "";
@@ -44,7 +45,7 @@ const renderButton = () => (
     src="near/widget/DIG.Button"
     props={{
       label: title,
-      disabled: !context.accountId || state.loading,
+      disabled: !context.accountId || state.loading || disabled,
       onClick: buttonClick,
       iconLeft: state.loading ? "bi-arrow-clockwise" : props.iconLeft,
       iconRight: state.loading ? "" : props.iconRight,


### PR DESCRIPTION
Fix: On overview page display logged in user instead of the moderator account.

Fix: Await graphql call in Moderation indexer to avoid indexer failure if there is an error.

Fix: Moderating an account from the Needs Moderation page writes to an incorrect Social.index key due to undefined path being appended.

Fix: Remove  receipt_id column in the needs_moderation as it is causing duplicates.

Fix: Correct subquery join for reporter list in unmoderated_reports to pull in reporters for reported accounts.

Feature: Disable Moderation buttons on Needs Moderation interface when not logged in as a moderator.