### PR TITLE
Add mobile view to the Settings page

### DIFF
--- a/src/Settings/Identity/Verifications/Card.jsx
+++ b/src/Settings/Identity/Verifications/Card.jsx
@@ -11,6 +11,11 @@ const Card = styled.div`
   gap: 14px;
   box-shadow: 0px 1px 2px 0px rgba(16, 24, 40, 0.06),
     0px 1px 3px 0px rgba(16, 24, 40, 0.1);
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 `;
 
 const TextWrapper = styled.div`
@@ -35,6 +40,11 @@ const Text = styled.span`
   color: #667085;
 `;
 
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex: 0 0 auto;
+`;
+
 return (
   <Card>
     {icon}
@@ -42,6 +52,8 @@ return (
       {title && <Title>{title}</Title>}
       <Text>{text}</Text>
     </TextWrapper>
-    {button}
+    <ButtonWrapper>
+      {button}
+    </ButtonWrapper>
   </Card>
 );

--- a/src/Settings/Index.jsx
+++ b/src/Settings/Index.jsx
@@ -9,6 +9,10 @@ const Wrapper = styled.div`
   grid-template-columns: 264px minmax(0, 1fr);
   align-items: start;
   height: 100%;
+
+  @media (max-width: 1024px) {
+    grid-template-columns: minmax(0, 1fr);
+  }
 `;
 
 const renderContent = () => {

--- a/src/Settings/Sidebar.jsx
+++ b/src/Settings/Sidebar.jsx
@@ -10,12 +10,21 @@ const Wrapper = styled.div`
   gap: 24px;
   width: 264px;
   height: 100%;
+
+  @media (max-width: 1024px) {
+    border-right: none;
+    width: 100%;
+  }
 `;
 
 const Title = styled.h2`
-  font: var(text-l);
+  font: var(--text-l);
   font-weight: 600;
-  padding: 64px 24px 24px;
+  padding: 64px 0 24px;
+
+  @media (max-width: 1024px) {
+    padding: 0;
+  }
 `;
 
 const MenuItem = styled.div`
@@ -80,7 +89,7 @@ return (
   <Wrapper>
     <Title>Settings</Title>
 
-    {filteredMenuItems.map((item) => (
+    {filteredMenuItems.length > 1 && filteredMenuItems.map((item) => (
       <MenuItem
         key={`settings-${item.id}`}
         onClick={() => onClick(item.id)}


### PR DESCRIPTION
This PR introduces a mobile view for Settings page. This is how it looks like:

<img width="1290" alt="Знімок екрана 2023-11-04 о 15 12 05" src="https://github.com/near/near-discovery-components/assets/34593263/2d92ebe5-e98f-455b-b209-e84d23905ade">
<img width="984" alt="Знімок екрана 2023-11-04 о 15 12 16" src="https://github.com/near/near-discovery-components/assets/34593263/44d10963-e749-4915-ad0f-5af1c32fcbaf">

I have hidden the tabs in the Sidebar because so far we only have 1 tab. If we add more tabs they will be shown automatically.