### PR TITLE
Show tab content on settings page

### DIFF
--- a/src/Settings/Identity/Verifications/Card.jsx
+++ b/src/Settings/Identity/Verifications/Card.jsx
@@ -23,6 +23,7 @@ const TextWrapper = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: 6px;
+  flex: 1 1 auto;
 `;
 
 const Title = styled.h2`

--- a/src/Settings/Index.jsx
+++ b/src/Settings/Index.jsx
@@ -1,21 +1,22 @@
 let { idosConnected, ...forwardedProps } = props;
 
-const activeTab = Storage.get("settings-tab");
+const activeTab = Storage.get("settings-tab") ?? "identity";
 // tab names: account, content, news, identity, notifications
 
+// Uncomment this when we have implement more then one tab.
 const Wrapper = styled.div`
-  display: grid;
-  gap: 40px;
-  grid-template-columns: 264px minmax(0, 1fr);
-  align-items: start;
-  height: 100%;
+  // display: grid;
+  // gap: 40px;
+  // grid-template-columns: 264px minmax(0, 1fr);
+  // align-items: start;
+  // height: 100%;
 
-  @media (max-width: 1024px) {
-    grid-template-columns: minmax(0, 1fr);
-  }
+  // @media (max-width: 1024px) {
+  //   grid-template-columns: minmax(0, 1fr);
+  // }
 `;
 
-const renderContent = () => {
+const SettingsContent = () => {
   switch (activeTab) {
     case "account":
     case "content":
@@ -23,9 +24,8 @@ const renderContent = () => {
     case "notifications":
       return <div>Not implemented yet</div>;
     case "identity":
+      default:
       return <Widget src="${REPL_ACCOUNT}/widget/Settings.Identity.Index" props={{ idosConnected, ...forwardedProps }} />;
-    default:
-      return null;
   }
 };
 
@@ -33,15 +33,19 @@ const handleMenuClick = (value) => {
   Storage.set("settings-tab", value);
 };
 
+// So far we have only implemented the identity tab. That's why we don't want to show Sidebar yet.
+const Sidebar = () => (
+  <Widget
+    src="${REPL_ACCOUNT}/widget/Settings.Sidebar"
+    props={{
+      onClick: handleMenuClick,
+      activeTab
+    }}
+  />
+);
+
 return (
   <Wrapper className="container-xl">
-    <Widget
-      src="${REPL_ACCOUNT}/widget/Settings.Sidebar"
-      props={{
-        onClick: handleMenuClick,
-        activeTab
-      }}
-    />
-    {renderContent()}
+    <SettingsContent />
   </Wrapper>
 );


### PR DESCRIPTION
As soon as we have only one implemented tab there is no need to show `<Sidebar />` with tabs. This PR introduces changes to layout before we don't implement more tabs.

Preview:

<img width="1356" alt="Знімок екрана 2023-11-06 о 14 23 46" src="https://github.com/near/near-discovery-components/assets/34593263/a9557a78-de5f-4a34-8e74-747b4f39e204">
