### PR TITLE
Replace Graphql Calls with Context Db Calls

### DIFF
--- a/indexers/social_feed/social_feed.js
+++ b/indexers/social_feed/social_feed.js
@@ -40,7 +40,7 @@ async function getBlock(block: Block) {
       console.log(`Post by ${accountId} has been added to the database`);
     } catch (e) {
       console.log(
-        `Failed to store post by ${accountId} to the database (perhaps it already stored)`
+        `Failed to store post by ${accountId} to the database (perhaps it is already stored)`
       );
     }
   }


### PR DESCRIPTION
The introduction of context.db methods allows for simpler databasse interaction. I've replaced the graphql calls with db calls to demonstrate the gains in simplicity. In addition, the blocks 100505912 and 105013604 both cause the indexer to crash. I've added more try catches to ensure the indexer skips those blocks rather than crashes. 