### PR TITLE
fix stats for ncon app quest

### DIFF
--- a/src/AppLibrary/Nearcon/IndexPage.jsx
+++ b/src/AppLibrary/Nearcon/IndexPage.jsx
@@ -63,7 +63,7 @@ function loadData() {
     .then((res) => {
       const apps = JSON.parse(res.body).data.map((app_raw) => {
         const app = JSON.parse(app_raw);
-        app.votes = app.widget_name.length;
+        app.votes = app.num_votes;
         app.recentTag = app.lastest_tag;
         const uniqueTags = Array.from(new Set(app.tags));
         app.tags = uniqueTags;


### PR DESCRIPTION
This change was accidentally checked in and thus is counting the leaderboard wrong.