### PR TITLE
Show data availability link in footer

### DIFF
--- a/src/NearOrg/Footer.jsx
+++ b/src/NearOrg/Footer.jsx
@@ -103,13 +103,10 @@ const sections = [
         title: "Data Infrastructure",
         url: "/data-infrastructure",
       },
-
-      // The following link should be uncommented and deployed on Nov 9th:
-
-      // {
-      //   title: "Data Availability",
-      //   url: "/data-availability",
-      // },
+      {
+        title: "Data Availability",
+        url: "/data-availability",
+      },
     ],
   },
   {


### PR DESCRIPTION
We can safely merge this into `develop` now. We'll open another PR to sync `main` tomorrow (on the 8th).