### PR TITLE
Fix `Add Credentials` button on settings page

### DIFF
--- a/src/Settings/Identity/Index.jsx
+++ b/src/Settings/Identity/Index.jsx
@@ -1,7 +1,7 @@
-const fractalModal = Storage.get("fractal-alert") ?? null;
-
 const [showBanner, setShowBanner] = useState(false);
-const modalOpen = fractalModal?.alert ?? false;
+
+// const modalOpen = fractalModal?.alert ?? false;
+// const fractalModal = Storage.get("fractal-alert") ?? null;
 
 const Wrapper = styled.div`
   display: flex;
@@ -61,7 +61,8 @@ return (
       <Widget src="${REPL_ACCOUNT}/widget/Settings.Identity.Verifications.Index" props={{ ...props }} />
     )}
 
-    <Widget
+    {/* For some reson this modal won't fires up for KYC that's why we hide it for now */}
+    {/* <Widget
       src="${REPL_ACCOUNT}/widget/Settings.Identity.Alert"
       props={{
         open: modalOpen,
@@ -70,6 +71,6 @@ return (
         onCancel: () => Storage.set("fractal-alert", { alert: false, href: null }),
         onConfirm: () => {},
       }}
-    />
+    /> */}
   </Wrapper>
 );

--- a/src/Settings/Identity/Verifications/Index.jsx
+++ b/src/Settings/Identity/Verifications/Index.jsx
@@ -54,7 +54,7 @@ const IconSealCheck = () => (
   </IconWrapper>
 );
 
-const CredentialButton = ({ href, disabled, onClick }) => (
+const CredentialButton = ({ href, onClick }) => (
   <Widget
     src="${REPL_ACCOUNT}/widget/DIG.Button"
     props={{
@@ -63,7 +63,7 @@ const CredentialButton = ({ href, disabled, onClick }) => (
       iconRight: "ph-bold ph-arrow-square-out",
       href,
       className: "ms-auto",
-      disabled: disabled ?? !context.accountId,
+      disabled: !context.accountId,
       onClick,
     }}
   />
@@ -76,7 +76,7 @@ const verificationItems = [
     text: "This verification helps other users know that you are not a bot. Choose from various providers to earn this verification badge.",
     icon: <IconSealUser />,
     verified: false,
-    button: <CredentialButton onClick={() => Storage.set("fractal-alert", { alert: true, href: proofOfPersonhoodLink })} />,
+    button: <CredentialButton href={proofOfPersonhoodLink} />,
   },
   {
     id: "plus",
@@ -84,7 +84,7 @@ const verificationItems = [
     text: "This verification helps other users trust transactions with your account. Choose from various providers to earn this verification badge.",
     icon: <IconSealCheck />,
     verified: false,
-    button: <CredentialButton onClick={() => Storage.set("fractal-alert", { alert: true, href: kycLink })} />,
+    button: <CredentialButton href={kycLink} />,
   },
 ];
 


### PR DESCRIPTION
For some reason the modal won't fires up after clicking on `Add Credential` button. There is no error or so and I can reproduce this issue very rarely. That's why I decided to remove modal and user will be redirected to fractal after clicking on  `Add Credential` button.