### PR TITLE
Fix Ecosystem Links

### DIFF
--- a/src/DIG/Button.jsx
+++ b/src/DIG/Button.jsx
@@ -13,6 +13,12 @@ let {
   ...forwardedProps
 } = props;
 
+if (forwardedProps.as) {
+  throw new Error(
+    'Invalid prop "as" passed to DIG.Button. If you need to render an anchor instead of a button, simply pass a "href" prop.'
+  );
+}
+
 fill = fill ?? "solid";
 size = size ?? "default";
 type = type ?? "button";

--- a/src/NearOrg/Ecosystem/CommunityPage.jsx
+++ b/src/NearOrg/Ecosystem/CommunityPage.jsx
@@ -295,7 +295,6 @@ return (
                       variant: "primary",
                       fill: "outline",
                       size: "large",
-                      as: "a",
                       target: "_blank",
                     }}
                   />
@@ -377,7 +376,6 @@ return (
                     variant: "primary",
                     fill: "outline",
                     size: "small",
-                    as: "a",
                     target: "_blank",
                   }}
                 />
@@ -417,7 +415,6 @@ return (
                     variant: "primary",
                     fill: "outline",
                     size: "small",
-                    as: "a",
                     target: "_blank",
                   }}
                 />
@@ -449,7 +446,6 @@ return (
                           variant: "primary",
                           fill: "outline",
                           size: "small",
-                          as: "a",
                           target: "_blank",
                         }}
                       />

--- a/src/NearOrg/Ecosystem/GetFundingPage.jsx
+++ b/src/NearOrg/Ecosystem/GetFundingPage.jsx
@@ -406,7 +406,6 @@ return (
                               variant: "primary",
                               fill: "outline",
                               size: "small",
-                              as: "a",
                               target: "_blank",
                             }}
                           />

--- a/src/NearOrg/Ecosystem/OverviewPage.jsx
+++ b/src/NearOrg/Ecosystem/OverviewPage.jsx
@@ -531,7 +531,6 @@ return (
               label: "Visit AwesomeNEAR",
               variant: "affirmative",
               size: "large",
-              as: "a",
               target: "_blank",
             }}
           />
@@ -582,7 +581,6 @@ return (
                   variant: "primary",
                   fill: "outline",
                   size: "large",
-                  as: "a",
                   target: "_blank",
                 }}
               />
@@ -615,7 +613,6 @@ return (
                   variant: "primary",
                   fill: "outline",
                   size: "large",
-                  as: "a",
                   target: "_blank",
                 }}
               />
@@ -648,7 +645,6 @@ return (
                   variant: "primary",
                   fill: "outline",
                   size: "large",
-                  as: "a",
                   target: "_blank",
                 }}
               />
@@ -689,7 +685,6 @@ return (
                     variant: "primary",
                     fill: "outline",
                     size: "large",
-                    as: "a",
                     target: "_blank",
                   }}
                 />
@@ -705,7 +700,6 @@ return (
                 label: "Browse DAOs on AstroDAO",
                 variant: "affirmative",
                 size: "large",
-                as: "a",
                 target: "_blank",
               }}
             />
@@ -756,7 +750,6 @@ return (
                   label: "Create a new DAO",
                   variant: "affirmative",
                   size: "large",
-                  as: "a",
                   target: "_blank",
                 }}
               />
@@ -878,7 +871,6 @@ return (
                       label: "Browse Governance Forum",
                       variant: "affirmative",
                       size: "large",
-                      as: "a",
                       target: "_blank",
                     }}
                   />
@@ -928,7 +920,6 @@ return (
                       label: "Read on Medium",
                       variant: "destructive",
                       size: "large",
-                      as: "a",
                       target: "_blank",
                     }}
                   />
@@ -1132,7 +1123,6 @@ return (
                     variant: "primary",
                     fill: "outline",
                     size: "large",
-                    as: "a",
                     target: "_blank",
                   }}
                 />
@@ -1177,7 +1167,6 @@ return (
                     variant: "primary",
                     fill: "outline",
                     size: "large",
-                    as: "a",
                     target: "_blank",
                   }}
                 />
@@ -1249,7 +1238,6 @@ return (
                   variant: "primary",
                   fill: "outline",
                   size: "large",
-                  as: "a",
                   target: "_blank",
                 }}
               />
@@ -1303,7 +1291,6 @@ return (
                         variant: "primary",
                         fill: "outline",
                         size: "large",
-                        as: "a",
                         target: "_blank",
                       }}
                     />
@@ -1379,7 +1366,6 @@ return (
                       variant: "primary",
                       fill: "outline",
                       size: "large",
-                      as: "a",
                       target: "_blank",
                     }}
                   />
@@ -1401,7 +1387,6 @@ return (
                       variant: "primary",
                       fill: "outline",
                       size: "large",
-                      as: "a",
                       target: "_blank",
                     }}
                   />
@@ -1417,7 +1402,6 @@ return (
                     variant: "primary",
                     fill: "outline",
                     size: "large",
-                    as: "a",
                     target: "_blank",
                   }}
                 />
@@ -1504,7 +1488,6 @@ return (
                 variant: "primary",
                 fill: "outline",
                 size: "large",
-                as: "a",
                 target: "_blank",
               }}
             />
@@ -1532,7 +1515,6 @@ return (
                 variant: "primary",
                 fill: "outline",
                 size: "large",
-                as: "a",
                 target: "_blank",
               }}
             />
@@ -1583,7 +1565,6 @@ return (
                   variant: "primary",
                   fill: "outline",
                   size: "large",
-                  as: "a",
                   target: "_blank",
                 }}
               />
@@ -1629,7 +1610,6 @@ return (
                       variant: "primary",
                       fill: "outline",
                       size: "large",
-                      as: "a",
                       target: "_blank",
                     }}
                   />
@@ -1686,7 +1666,6 @@ return (
                   variant: "primary",
                   fill: "outline",
                   size: "large",
-                  as: "a",
                   target: "_blank",
                 }}
               />
@@ -1732,7 +1711,6 @@ return (
                   variant: "primary",
                   fill: "outline",
                   size: "large",
-                  as: "a",
                   target: "_blank",
                 }}
               />
@@ -1804,7 +1782,6 @@ return (
                       variant: "primary",
                       fill: "outline",
                       size: "large",
-                      as: "a",
                       target: "_blank",
                     }}
                   />

--- a/src/NearOrg/Ecosystem/WorkAndEarnPage.jsx
+++ b/src/NearOrg/Ecosystem/WorkAndEarnPage.jsx
@@ -131,7 +131,6 @@ return (
                     label: "Full-time Jobs across the Ecosystem",
                     variant: "primary",
                     fill: "outline",
-                    as: "a",
                     target: "_blank",
                   }}
                 />
@@ -143,7 +142,6 @@ return (
                     label: "Become an ambassador or teacher",
                     variant: "primary",
                     fill: "outline",
-                    as: "a",
                     target: "_blank",
                   }}
                 />
@@ -197,7 +195,6 @@ return (
                     label: "View Bounties",
                     variant: "primary",
                     fill: "outline",
-                    as: "a",
                     target: "_blank",
                   }}
                 />


### PR DESCRIPTION
Closes: https://github.com/near/near-discovery-components/issues/524

Turns out that passing `as: "a"` to our DIG.Button as a prop was breaking the conditional anchor implementation. I added logic to DIG.Button to avoid this error in the future.