### PR TITLE
fix: Fix link to DevHub posts on notifications page

### DIFF
--- a/src/NearOrg/Notifications/Notification.jsx
+++ b/src/NearOrg/Notifications/Notification.jsx
@@ -136,12 +136,13 @@ let { blockHeight, accountId, manageNotification, permission } = props;
 let postUrl = "";
 
 // Construct DevGov postUrl
+// TODO: refactor this method
 function buildPostUrl(widgetName, linkProps) {
   linkProps = { ...linkProps };
 
   const nearDevGovGigsWidgetsAccountId =
     props.nearDevGovGigsWidgetsAccountId ||
-    (context.widgetSrc ?? "devgovgigs.near").split("/", 1)[0];
+    "devgovgigs.near";
 
   if (props.nearDevGovGigsContractAccountId) {
     linkProps.nearDevGovGigsContractAccountId =


### PR DESCRIPTION
This PR introduces a fix for DevHub post links on notifications page.

Closes [#830](https://github.com/near/near-discovery/issues/830)