### PR TITLE
refactor: Limit number of indexed Post in nearWeekNews

### DIFF
--- a/src/News/NearweekSidebarFeed.jsx
+++ b/src/News/NearweekSidebarFeed.jsx
@@ -1,5 +1,5 @@
 const accountId = "near";
-const limit = 5;
+const limit = porps.limit || 5;
 let posts = [];
 
 const indexedPosts = Social.index("post", "main", {

--- a/src/News/NearweekSidebarFeed.jsx
+++ b/src/News/NearweekSidebarFeed.jsx
@@ -4,7 +4,7 @@ let posts = [];
 
 const indexedPosts = Social.index("post", "main", {
   accountId,
-  limit: 20,
+  limit: limit,
   order: "desc",
 });
 

--- a/src/News/NearweekSidebarFeed.jsx
+++ b/src/News/NearweekSidebarFeed.jsx
@@ -1,5 +1,5 @@
 const accountId = "near";
-const limit = porps.limit || 5;
+const limit = props.limit || 5;
 let posts = [];
 
 const indexedPosts = Social.index("post", "main", {


### PR DESCRIPTION
This pull request is submitted as a suggestion to address the issue:
https://github.com/near/near-discovery-components/issues/459

Limited the number of posts fetched from the `Social.index`
Since we display only 5 posts on the sidebar, fetching more would be unnecessary.
So in this case we limited the number of `indexed posts` by the `limit` value.
With this adjustment, we've successfully reduced the number of HTTP requests.
