### PR TITLE
feat: Add click directly on TabsButton

### DIFF
--- a/src/ActivityPage.jsx
+++ b/src/ActivityPage.jsx
@@ -102,15 +102,27 @@ const TabsButton = styled("Link")`
 return (
   <Wrapper className="container-xl" negativeMargin={selectedTab === "posts"}>
     <Tabs halfMargin={selectedTab === "apps"} noMargin={selectedTab === "posts"}>
-      <TabsButton href={`${activityUrl}?tab=posts`} selected={selectedTab === "posts"}>
+      <TabsButton
+        href={`${activityUrl}?tab=posts`}
+        selected={selectedTab === "posts"}
+        onClick={() => setSelectedTab("posts")}
+      >
         Posts
       </TabsButton>
 
-      <TabsButton href={`${activityUrl}?tab=apps`} selected={selectedTab === "apps"}>
+      <TabsButton
+        href={`${activityUrl}?tab=apps`}
+        selected={selectedTab === "apps"}
+        onClick={() => setSelectedTab("apps")}
+      >
         Components
       </TabsButton>
 
-      <TabsButton href={`${activityUrl}?tab=explore`} selected={selectedTab === "explore"}>
+      <TabsButton
+        href={`${activityUrl}?tab=explore`}
+        selected={selectedTab === "explore"}
+        onClick={() => setSelectedTab("explore")}
+      >
         Explore
       </TabsButton>
     </Tabs>


### PR DESCRIPTION
Added `onClick` handler directly to the `TabsButton` component to set the selected tab with `setSelectedTab`.
Closes https://github.com/near/near-discovery/issues/693