### PR TITLE
Fix DIG.OverviewPage Fetch

### DIFF
--- a/src/DIG/OverviewPage.jsx
+++ b/src/DIG/OverviewPage.jsx
@@ -1,27 +1,30 @@
-State.init({
-  selectedComponentName: props.component,
-});
-
 const overviewPageUrl = "/${REPL_ACCOUNT}/widget/DIG.OverviewPage";
-const author = "${REPL_ACCOUNT}";
-const data = Social.get(`${author}/widget/**`) ?? {};
-const componentNames = Object.keys(data)
+const authorId = "${REPL_ACCOUNT}";
+const defaultData = {
+  [authorId]: {
+    widget: {},
+  },
+};
+
+const keysData = Social.keys(`${authorId}/widget/*`) ?? defaultData;
+const componentNames = Object.keys(keysData[authorId].widget)
   .filter((item) => {
     return item.indexOf("DIG.") > -1 && item.indexOf("OverviewPage") === -1;
   })
   .sort();
-const selectedComponentName = state.selectedComponentName ?? componentNames[0];
-const selectedComponent = data[selectedComponentName];
 
-if (props.component && props.component !== state.selectedComponentName) {
-  State.update({
-    selectedComponentName: props.component,
-  });
-}
+const data =
+  componentNames.length > 0
+    ? Social.get(componentNames.map((name) => `${authorId}/widget/${name}/**`)) ?? defaultData
+    : defaultData;
+const components = data[authorId].widget;
+
+const selectedComponentName = props.component ?? componentNames[0];
+const selectedComponent = components[selectedComponentName];
 
 function returnExampleCodeForComponent(componentName) {
   if (!componentName) return;
-  const component = data[componentName];
+  const component = components[componentName];
   if (!component?.metadata?.description) return;
 
   /*
@@ -35,7 +38,7 @@ function returnExampleCodeForComponent(componentName) {
     hardcoded, so we need to dynamically replace it with `author` to
     properly handle testnet and mainnet:
   */
-  const code = (matches[1] ?? "").replace(/src="near\/widget/g, `src="${author}/widget`);
+  const code = (matches[1] ?? "").replace(/src="near\/widget/g, `src="${authorId}/widget`);
 
   if (code) {
     /*
@@ -189,7 +192,7 @@ return (
                 props={{
                   label: "View Details",
                   iconRight: "ph-bold ph-arrow-right",
-                  href: `/${author}/widget/ComponentDetailsPage?src=${author}/widget/${selectedComponentName}`,
+                  href: `/${authorId}/widget/ComponentDetailsPage?src=${authorId}/widget/${selectedComponentName}`,
                   variant: "primary",
                   fill: "outline",
                   size: "small",


### PR DESCRIPTION
Fixes: https://github.com/near/near-discovery/issues/872

Turns out we were hitting a gas limit due to our previous logic fetching all components on our official account (including their code). Now we only fetch the full details of our `DIG` components.