### PR TITLE
fix: Remove Flag button from Posts and Comments

### DIFF
--- a/src/Comments/Comment.jsx
+++ b/src/Comments/Comment.jsx
@@ -266,16 +266,6 @@ return (
                     url: commentUrl,
                   }}
                 />
-                <Widget
-                  src="${REPL_ACCOUNT}/widget/FlagButton"
-                  props={{
-                    item,
-                    disabled: !context.accountId || context.accountId === accountId,
-                    onFlag: () => {
-                      State.update({ hasBeenFlagged: true });
-                    },
-                  }}
-                />
               </Actions>
             )}
 

--- a/src/Posts/Post.jsx
+++ b/src/Posts/Post.jsx
@@ -350,16 +350,6 @@ return (
                     url: postUrl,
                   }}
                 />
-                <Widget
-                  src="${REPL_ACCOUNT}/widget/FlagButton"
-                  props={{
-                    item,
-                    disabled: !context.accountId || context.accountId === accountId,
-                    onFlag: () => {
-                      State.update({ hasBeenFlagged: true });
-                    },
-                  }}
-                />
               </Actions>
             )}
             {state.showReply && (


### PR DESCRIPTION
This PR addresses the flag button ( image below ) and removes it from both posts and comments, as we have the `three dots menu` in the report option instead.

![image](https://github.com/near/near-discovery-components/assets/95851348/7fc05fe9-793f-4af1-bc12-ff7e09a0c89d)
