### PR TITLE
feat: update unseen posts every 5s 

### DIFF
--- a/src/ActivityFeeds/DetermineActivityFeed.jsx
+++ b/src/ActivityFeeds/DetermineActivityFeed.jsx
@@ -5,9 +5,13 @@ let lastPostSocialApi = Social.index("post", "main", {
   order: "desc",
 });
 
+if (lastPostSocialApi == null) {
+  return "Loading...";
+}
+
 State.init({
   // If QueryAPI Feed is lagging behind Social API, fallback to old widget.
-  shouldFallback: props.shouldFallback === "true" || props.shouldFallback === true,
+  shouldFallback: false,
 });
 
 function fetchGraphQL(operationsDoc, operationName, variables) {
@@ -38,14 +42,20 @@ fetchGraphQL(lastPostQuery, "IndexerQuery", {})
 
       const lag = nearSocialBlockHeight - feedIndexerBlockHeight;
       let shouldFallback = lag > 2 || !feedIndexerBlockHeight;
-      State.update({ shouldFallback });
+      if (shouldFallback === true) {
+        console.log(
+          "Falling back to Social index feed. Block difference is: ",
+          nearSocialBlockHeight - feedIndexerBlockHeight,
+        );
+        State.update({ shouldFallback });
+      }
     } else {
-      console.log("Falling back to old widget.");
+      console.log("Falling back to Social index feed. No QueryApi data received.");
       State.update({ shouldFallback: true });
     }
   })
   .catch((error) => {
-    console.log("Error while fetching GraphQL(falling back to old widget): ", error);
+    console.log("Error while fetching QueryApi feed (falling back to index feed): ", error);
     State.update({ shouldFallback: true });
   });
 

--- a/src/ActivityPage.jsx
+++ b/src/ActivityPage.jsx
@@ -134,12 +134,7 @@ return (
       </Section>
 
       <Section negativeMargin primary active={selectedTab === "posts"}>
-        <Widget
-          src={`${REPL_ACCOUNT}/widget/ActivityFeeds.DetermineActivityFeed`}
-          props={{
-            shouldFallback: props.shouldFallback,
-          }}
-        />
+        <Widget src={`${REPL_ACCOUNT}/widget/ActivityFeeds.DetermineActivityFeed`} />
       </Section>
 
       <Section active={selectedTab === "explore"}>


### PR DESCRIPTION
Every 5s, fetches latest posts and adds them to the `newUnseenPosts` list.
When new posts are present shows refresh control. Clicking that will add the unseen posts to the displayed list (preserving all loaded posts) and resets the `initialQueryTime` used by the update task.
Paging uses the `initialQueryTime` to keep the offset constant when paging.

![Screenshot 2023-12-14 at 4 57 13 PM](https://github.com/near/near-discovery-components/assets/671506/77c47a53-9b97-4042-b2e3-13543cf8efc3)

Minor updates to sort selector and its text to get closer to the latest UI designs
