### PR TITLE
NEAR-448 FIX: Updated z-index for Radix Popover due to underlying UI issues

### DIFF
--- a/src/DIG/DropdownMenu.jsx
+++ b/src/DIG/DropdownMenu.jsx
@@ -17,6 +17,7 @@ const Content = styled("DropdownMenu.Content")`
   animation-duration: 400ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   will-change: transform, opacity;
+  z-index: 99999; //To show before navigation
 
   &[data-side="bottom"] {
     animation-name: slideUpAndFade;


### PR DESCRIPTION
This pull request addresses a UI concern related to the Post action dropdown showing after the newsletter section 
as documented in: [Issue: 448](https://github.com/near/near-discovery-components/issues/448)

Added z-index to Radix Popover Content since it has a fixed position.

Note: This change will result in also resolving the Profile Overlay Display issue [#879](https://github.com/near/near-discovery/issues/879)
