### PR TITLE
NEAR-879 FIX: Updated z-index for profile overlay issue

### DIFF
--- a/src/AccountProfileOverlay.jsx
+++ b/src/AccountProfileOverlay.jsx
@@ -39,6 +39,7 @@ const HoverCardContent = styled("HoverCard.Content")`
   animation: fadeIn 200ms 100ms forwards;
   opacity: 0;
   pointer-events: none;
+  z-index: 1001;
 
   @keyframes fadeIn {
     0% {

--- a/src/Posts/Post.jsx
+++ b/src/Posts/Post.jsx
@@ -107,7 +107,9 @@ query IndexerQuery {
 
 const Post = styled.div`
   position: relative;
-
+  div[data-radix-popper-content-wrapper] {
+    z-index: 99999 !important;  //to override the inline popover auto index
+  }
   &::before {
     content: "";
     display: block;

--- a/src/Posts/Post.jsx
+++ b/src/Posts/Post.jsx
@@ -107,9 +107,6 @@ query IndexerQuery {
 
 const Post = styled.div`
   position: relative;
-  div[data-radix-popper-content-wrapper] {
-    z-index: 99999 !important;  //to override the inline popover auto index
-  }
   &::before {
     content: "";
     display: block;


### PR DESCRIPTION
Due to Radix Popover having set the z-index to auto, most of the content which have a higher z-index will result in the Profile Overlay showing before content.

This PR will close this issue: [Issue: 879](https://github.com/near/near-discovery/issues/879)