### PR TITLE
fix: fixed styling bugs in profile editor view

### DIFF
--- a/src/ProfilePage.jsx
+++ b/src/ProfilePage.jsx
@@ -39,14 +39,9 @@ const Wrapper = styled.div`
 `;
 
 const Main = styled.div`
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
   gap: 40px;
-  grid-template-columns: 352px minmax(0, 1fr);
-  align-items: start;
-
-  @media (max-width: 1024px) {
-    grid-template-columns: minmax(0, 1fr);
-  }
 `;
 
 const BackgroundImage = styled.div`
@@ -76,6 +71,7 @@ const SidebarWrapper = styled.div`
   position: relative;
   z-index: 5;
   margin-top: -55px;
+  min-width: 352px;
 
   @media (max-width: 1024px) {
     margin-top: -40px;
@@ -83,6 +79,9 @@ const SidebarWrapper = styled.div`
 `;
 
 const Content = styled.div`
+  min-width: fit-content;
+  flex-grow: 1;
+
   .post {
     padding-left: 0;
     padding-right: 0;
@@ -132,6 +131,7 @@ const TabsButton = styled("Link")`
   outline: none;
   text-align: center;
   text-decoration: none !important;
+  white-space: nowrap;
 
   &:hover {
     color: #11181c;


### PR DESCRIPTION
Fixes: https://github.com/near/near-discovery/issues/843

The issue here was with using `display: grid` with wrong media breakpoints. It was still rendering the desktop version of main section when it was too small. Since the breakpoint was set to `1024px` and the section was rendered on half of the screen it didn't have room to display correctly.

**Solution:**
Instead of using `display: grid` I used `display: flex` and set it to wrap automatically when there is no more room for the content to display correctly.

Regarding the fourth point in the issue ("'Most recent' dropdown looks buggy and 'Sort by' has incorrect font - bug"):
It looks like the layout is different now and there is no sorting feature anymore.

Before                            |  After
:-------------------------:|:-------------------------:
![image](https://github.com/near/near-discovery-components/assets/95852708/4c4b4333-0ed2-448f-ac85-9999133720c0) | ![image](https://github.com/near/near-discovery-components/assets/95852708/0cee71e0-2f20-4e31-ad1d-94e7393f7726)

