### PR TITLE
fix: Replaced a with Link to prevent unnecessary page reloads on profile

### DIFF
--- a/src/AccountProfile.jsx
+++ b/src/AccountProfile.jsx
@@ -75,7 +75,7 @@ const Name = styled.div`
 
 const AccountProfile = (
   <Wrapper
-    as={props.onClick ? "button" : "a"}
+    as={props.onClick ? "button" : "Link"}
     href={!props.onClick && profileUrl}
     onClick={props.onClick && (() => props.onClick(accountId))}
   >

--- a/src/Recommender/Account/AccountProfileSidebar.jsx
+++ b/src/Recommender/Account/AccountProfileSidebar.jsx
@@ -98,7 +98,7 @@ const Name = styled.div`
 
 const AccountProfile = (
   <Wrapper
-    as={props.onClick ? "button" : "a"}
+    as={props.onClick ? "button" : "Link"}
     href={!props.onClick && profileUrl}
     onClick={props.onClick && (() => props.onClick(accountId))}
   >


### PR DESCRIPTION
This pull request addresses the issue ( https://github.com/near/near-discovery-components/issues/596 ) of unnecessary page reloads when clicking on a user profile.
The change involves replacing the usage of the `a` element with the `Link` in two different files ( AccountProfile and AccountProfileSidebar. )