### PR TITLE
Adding contribution graph to profile page

### DIFF
--- a/src/ProfilePage.jsx
+++ b/src/ProfilePage.jsx
@@ -164,6 +164,10 @@ const Bio = styled.div`
   }
 `;
 
+const ContributionGraphWrapper = styled.div`
+  margin: 0 0 48px;
+`;
+
 if (profile === null) {
   return "Loading";
 }
@@ -239,6 +243,10 @@ return (
                 </Bio>
               </>
             )}
+
+            <ContributionGraphWrapper>
+              <Widget src="${REPL_ACCOUNT}/widget/DeveloperProfile.ContributionGraph" props={{ accountId }} />
+            </ContributionGraphWrapper>
 
             <Widget
               src="${REPL_ACCOUNT}/widget/ActivityFeeds.DetermineActivityFeed"


### PR DESCRIPTION
Closes: https://github.com/near/near-discovery-components/issues/590

We're still waiting for the backfill to finish on the indexer before we merge this, but everything is ready to go! Feel free to test out locally by visiting your profile page.

Account with contributions: http://localhost:3000/near/widget/ProfilePage?accountId=near

Account without any contributions: http://localhost:3000/near/widget/ProfilePage?accountId=joshford.near