### PR TITLE
Enable sending notifications for interactions on comment

### DIFF
--- a/replacements.testnet.json
+++ b/replacements.testnet.json
@@ -1,5 +1,4 @@
 {
-  "REPL_ACCOUNT": "discom.testnet",
   "REPL_MOB": "eugenethedream",
   "REPL_MOB_2": "one.testnet",
   "REPL_MODERATOR": "bosmod.testnet",

--- a/replacements.testnet.json
+++ b/replacements.testnet.json
@@ -1,4 +1,5 @@
 {
+  "REPL_ACCOUNT": "discom.testnet",
   "REPL_MOB": "eugenethedream",
   "REPL_MOB_2": "one.testnet",
   "REPL_MODERATOR": "bosmod.testnet",

--- a/src/Comments/Comment.jsx
+++ b/src/Comments/Comment.jsx
@@ -11,16 +11,8 @@ State.init({
   showToast: false,
   flaggedMessage: { header: "", detail: "" },
   content: JSON.parse(props.content) ?? undefined,
-  notifyAccountId: undefined,
+  notifyAccountId: accountId,
 });
-
-const extractNotifyAccountId = (parentItem) => {
-  if (!parentItem || parentItem.type !== "social" || !parentItem.path) {
-    return undefined;
-  }
-  const accountId = parentItem.path.split("/")[0];
-  return `${accountId}/post/main` === parentItem.path ? accountId : undefined;
-};
 
 const optimisticallyHideItem = (message) => {
   // State change here prevents Social.set from firing
@@ -275,7 +267,7 @@ return (
                   src="${REPL_ACCOUNT}/widget/Comments.Compose"
                   props={{
                     initialText: `@${accountId}, `,
-                    notifyAccountId: extractNotifyAccountId(state.content.item),
+                    notifyAccountId: accountId,
                     item: item,
                     onComment: () => State.update({ showReply: false }),
                   }}

--- a/src/Comments/Comment.jsx
+++ b/src/Comments/Comment.jsx
@@ -14,6 +14,14 @@ State.init({
   notifyAccountId: accountId,
 });
 
+const extractNotifyAccountId = (parentItem) => {
+  if (!parentItem || parentItem.type !== "social" || !parentItem.path) {
+    return undefined;
+  }
+  const accountId = parentItem.path.split("/")[0];
+  return `${accountId}/post/main` === parentItem.path ? accountId : undefined;
+};
+
 const optimisticallyHideItem = (message) => {
   // State change here prevents Social.set from firing
   // State.update({
@@ -267,7 +275,7 @@ return (
                   src="${REPL_ACCOUNT}/widget/Comments.Compose"
                   props={{
                     initialText: `@${accountId}, `,
-                    notifyAccountId: accountId,
+                    notifyAccountId: extractNotifyAccountId(state.content.item),
                     item: item,
                     onComment: () => State.update({ showReply: false }),
                   }}

--- a/src/v1/LikeButton.jsx
+++ b/src/v1/LikeButton.jsx
@@ -84,7 +84,7 @@ const likeClick = () => {
     },
   };
 
-  if (!hasLike && props.notifyAccountId) {
+  if (!hasLike && props.notifyAccountId && props.notifyAccountId !== context.accountId) {
     data.index.notify = JSON.stringify({
       key: props.notifyAccountId,
       value: {


### PR DESCRIPTION
Fixes: https://github.com/near/near-discovery/issues/668

There is already logic to handle notification sending when liking comment. 

The issue was with `notifyAccountId` being set to `undefined` in `src/Comments/Comment.jsx`. When checking whether to send notification `notifyAccountId` needs to be truthy. Since it was set to `undefined` and never modified after that it would not send the notification.

I also added a check to prevent sending notifications to yourself when liking own comment.