### PR TITLE
fix: Fixed notification long horizontal content 

### DIFF
--- a/src/NearOrg/Notifications/Notification.jsx
+++ b/src/NearOrg/Notifications/Notification.jsx
@@ -121,6 +121,7 @@ const Description = styled.span`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   text-overflow: ellipsis;
+  word-break: break-word;
 `;
 
 const Left = styled.div`


### PR DESCRIPTION
This PR addresses https://github.com/near/near-discovery/issues/908 with the issue of the long notification content UI ( picture below ).
![notification-content](https://github.com/near/near-discovery-components/assets/95851348/e13210f5-952c-4459-9a27-c50ea3d7012b)

- Added `word-break: break-word` to `Description` tag which fixed both cases in `notification` and `notification dropdown menu`.

