### PR TITLE
fix: correct reporter count & list on needs moderation page

### DIFF
--- a/indexers/moderation/moderation.sql
+++ b/indexers/moderation/moderation.sql
@@ -43,12 +43,13 @@ CREATE INDEX
     );
 
 CREATE VIEW dataplatform_near_moderation.unmoderated_reports as
-SELECT min(report_blockheight) as first_report_blockheight, count(account_id) as reporter_count,
+SELECT min(report_blockheight) as first_report_blockheight, count(distinct account_id) as reporter_count,
        array(select account_id from dataplatform_near_moderation.moderation_reporting rl
              WHERE ((rl.moderated_account_id = r.moderated_account_id)
-                        AND ((rl.moderated_path IS NULL) OR
+                        AND ((r.moderated_path IS NULL AND rl.moderated_path IS NULL) OR
                              ((rl.moderated_path = r.moderated_path) AND (rl.moderated_blockheight = r.moderated_blockheight))))
-             limit 5) as reporter_list,
+             AND rl.label != 'hide'
+             group by account_id limit 5) as reporter_list,
        moderated_account_id, moderated_path, moderated_blockheight,
        mode() within group (order by label) as most_frequent_label --  most prevalent label
 FROM dataplatform_near_moderation.moderation_reporting r

--- a/src/Moderation/NeedsModeration.jsx
+++ b/src/Moderation/NeedsModeration.jsx
@@ -234,6 +234,7 @@ const renderItem = (item) => {
   }
 
   const overviewTooltip = accountId + (blockHeight ? " " + blockHeight : "");
+  const reporterList = item.reporter_list ? item.reporter_list.join(", ") : "";
   const header = (
     <div key={id} style={{ width: "100%" }}>
       <div className="row">
@@ -247,7 +248,14 @@ const renderItem = (item) => {
           />
         </div>
         <div className="col-3">
-          {item.most_frequent_label} by {item.reporter_count} {item.reporter_count > 0 ? "users" : "user"}
+          {item.most_frequent_label} by
+          <Widget
+            src="near/widget/DIG.Tooltip"
+            props={{
+              content: reporterList,
+              trigger: ` ${item.reporter_count} ${item.reporter_count > 0 ? "users" : "user"}`,
+            }}
+          />
         </div>
         <div className="col-1">
           <Widget


### PR DESCRIPTION
Having multiple labels exposed an incorrect reporter count calculation on the Needs Moderation page. Added tooltip of sampled reporter list to confirm calculation. 