### PR TITLE
fix: fixed view notification button preview for like type notification

### DIFF
--- a/src/NearOrg/Notifications/utils.jsx
+++ b/src/NearOrg/Notifications/utils.jsx
@@ -77,7 +77,11 @@ function createNotificationLink(notificationType, notificationValue, authorAccou
         .map(([k, v]) => `${k}=${v}`)
         .join("&")}`;
     case "like":
+      const isComment = path.indexOf("/post/comment") > 0 || notificationType === "comment";
       const pathAccountId = path.split("/")[0];
+      if (isComment) {
+        return `${pathPrefix}/NearOrg.Notifications.CommentPost?accountId=${pathAccountId}&blockHeight=${likeAtBlockHeight}`;
+      }
       return `${pathPrefix}/PostPage?accountId=${pathAccountId}&blockHeight=${likeAtBlockHeight}`;
     case "comment":
       return `${pathPrefix}/PostPage?accountId=${authorAccountId}&commentBlockHeight=${blockHeight}`;


### PR DESCRIPTION
This pull request addresses the issue https://github.com/near/near-discovery-components/issues/626 for redirecting to the `Page not found` preview after clicking `view` on like type of notification.

- Added check for `isComment` to redirect to the `commentPost` page.