### PR TITLE
fix: fixed notification content description

### DIFF
--- a/src/NearOrg/Notifications/Notification.jsx
+++ b/src/NearOrg/Notifications/Notification.jsx
@@ -153,7 +153,7 @@ const ordinaryNotification = ["follow", "unfollow", "poke"].indexOf(type) >= 0;
 const notificationMessageByType = createNotificationMessage && createNotificationMessage(type, path, post, message);
 if (!notificationMessageByType) return "";
 
-const previewContent = getNotificationContent(type, path, post, context, accountId, blockHeight);
+const previewContent = getNotificationContent(type, value, path, post, context, accountId, blockHeight);
 const postUrl = createNotificationLink(type, value, props.initiator, accountId, blockHeight);
 const iconClassName = getNotificationIconClassName(type);
 

--- a/src/NearOrg/Notifications/utils.jsx
+++ b/src/NearOrg/Notifications/utils.jsx
@@ -39,9 +39,12 @@ function createNotificationMessage(notificationType, path, postValue, customMess
   }
 }
 
-function getNotificationContent(notificationType, path, postValue, context, accountId, blockHeight) {
+function getNotificationContent(notificationType, notificationValue, path, postValue, context, accountId, blockHeight) {
   // Do not show content for these notification types
   // as they are not having any content
+  let { item } = notificationValue;
+  let { blockHeight: likeAtBlockHeight } = item;
+
   if (["follow", "unfollow", "poke"].indexOf(notificationType) >= 0) return null;
 
   const isComment = path.indexOf("/post/comment") > 0 || notificationType === "comment";
@@ -53,8 +56,12 @@ function getNotificationContent(notificationType, path, postValue, context, acco
     });
     return getDevHubContent.snapshot.description;
   }
-  const contentPath = isPost ? `${context.accountId}/post/main` : `${accountId}/post/comment`;
-  const contentDescription = JSON.parse(Social.get(contentPath, blockHeight) ?? "null");
+
+  const commentAuthorAccountId = notificationType === "like" ? context.accountId : accountId;
+  const contentBlockHeight = notificationType === "like" ? likeAtBlockHeight : blockHeight;
+
+  const contentPath = isPost ? `${context.accountId}/post/main` : `${commentAuthorAccountId}/post/comment`;
+  const contentDescription = JSON.parse(Social.get(contentPath, contentBlockHeight) ?? "null");
   return contentDescription.text;
 }
 


### PR DESCRIPTION
This pull request resolves the first point raised in issue https://github.com/near/near-discovery/issues/909 which fixes the content description not matching the action.

- Introduction of the `notificationValue` property for `getNotificationContent` function.
- Added `commentAuthorAccountId` to get the specific accountId
- Addition of `contentBlockHeight` to accurately capture the blockHeight for notifications of type `like`.
- Refactored `contentPath` and `contentDescription`.