### PR TITLE
fix: add a `tags` field to accounts indexer schema

### DIFF
--- a/indexers/accounts/accounts.sql
+++ b/indexers/accounts/accounts.sql
@@ -9,5 +9,6 @@ CREATE TABLE
     "background_image" text,
     "horizon_tnc" boolean,
     "linktree" text,
+    "tags" text,
     PRIMARY KEY ("account_id")
   )


### PR DESCRIPTION
Relates to [#855](https://github.com/near/near-discovery/issues/855)