### PR TITLE
fix: Update UI when a new comment is added

### DIFF
--- a/src/Comments/Compose.jsx
+++ b/src/Comments/Compose.jsx
@@ -4,6 +4,7 @@ if (!context.accountId) {
 
 const autocompleteEnabled = true;
 const item = props.item;
+const newAddedComment = props.newAddedComment;
 
 State.init({
   image: {},
@@ -82,6 +83,17 @@ function composeData() {
 }
 
 function onCommit() {
+  const newComment = {
+    account_id: context.accountId,
+    block_height: "now",
+    block_timestamp: Date.now() * 1000000,
+    content: JSON.stringify({
+      type: "md",
+      text: state.text,
+    }),
+  };
+  newAddedComment(newComment);
+
   State.update({
     image: {},
     text: "",

--- a/src/Posts/Post.jsx
+++ b/src/Posts/Post.jsx
@@ -225,6 +225,10 @@ const renderComment = (a) => {
 
 const renderedComments = state.comments.map(renderComment);
 
+const addNewCommentFn = (newComment) => {
+  State.update(state.comments.push(newComment));
+};
+
 return (
   <>
     {state.showToast && (
@@ -359,6 +363,7 @@ return (
                     notifyAccountId,
                     item,
                     onComment: () => State.update({ showReply: false }),
+                    newAddedComment: addNewCommentFn,
                   }}
                 />
               </div>


### PR DESCRIPTION
This draft PR aims to address the issue raised in https://github.com/near/near-discovery-components/issues/433 regarding updating the UI when a new comment is added to a post.

- Added `const newComment` when adding a comment.
- Added `addNewCommentFn` function to update the `state.comments` when a comment is pushed.
- Updated `Comments.Compose` widget.

The picture below shows what the last added comment will look like without reloading the page.
![image](https://github.com/near/near-discovery-components/assets/95851348/54161720-a539-4c65-b6bb-86a66ca30b82)

In the provided image, the latest added comment is displayed without the expected widgets for like, comment, and share. because of the `blockHeight` which is currently set to `now`. 

