### PR TITLE
fix: trusted partners display should flex to mobile screens

### DIFF
--- a/src/NearOrg/DataAvailabilityPage.jsx
+++ b/src/NearOrg/DataAvailabilityPage.jsx
@@ -207,6 +207,8 @@ const LogoLinksWrapper = styled.div`
 const LogoLinks = styled.div`
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
   gap: 60px;
   padding: 16px 24px;
 
@@ -298,6 +300,8 @@ const web3Teams = [
     height: "24px",
   },
 ];
+
+const web3TeamsCombined = [...web3Teams, ...web3Teams2];
 
 return (
   <Wrapper>
@@ -412,40 +416,23 @@ return (
 
       <LogoLinksWrapper>
         <LogoLinks>
-          {web3Teams.map((team) => {
-            return (
-              <a
-                href={team.url}
-                target="_blank"
-                title={team.name}
-                style={{ height: team.height, display: "inline-block" }}
-                key={team.name}
-              >
-                <Widget
-                  src="${REPL_MOB}/widget/Image"
-                  props={{
-                    image: returnIpfsImage(team.ipfsImage),
-                    alt: team.name,
-                  }}
-                />
-              </a>
-            );
-          })}
-        </LogoLinks>
-        <LogoLinks>
-          {web3Teams2.map((team) => {
-            return (
-              <a href={team.url} target="_blank" title={team.name} style={{ height: team.height }} key={team.name}>
-                <Widget
-                  src="${REPL_MOB}/widget/Image"
-                  props={{
-                    image: returnIpfsImage(team.ipfsImage),
-                    alt: team.name,
-                  }}
-                />
-              </a>
-            );
-          })}
+          {web3TeamsCombined.map((team) => (
+            <Link
+              href={team.url}
+              target="_blank"
+              title={team.name}
+              style={{ height: team.height, display: "inline-block" }}
+              key={team.name}
+            >
+              <Widget
+                src="${REPL_MOB}/widget/Image"
+                props={{
+                  image: returnIpfsImage(team.ipfsImage),
+                  alt: team.name,
+                }}
+              />
+            </Link>
+          ))}
         </LogoLinks>
       </LogoLinksWrapper>
       {/* </Teams> */}

--- a/src/NearOrg/HomePage.jsx
+++ b/src/NearOrg/HomePage.jsx
@@ -143,6 +143,8 @@ const web3Teams = [
   //},
 ];
 
+const web3TeamsCombined = [...web3Teams, ...web3Teams2];
+
 const learnItems = [
   {
     name: "Docs",
@@ -362,6 +364,8 @@ const LogoLinksWrapper = styled.div`
 const LogoLinks = styled.div`
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
   gap: 60px;
   padding: 16px 24px;
 
@@ -551,34 +555,17 @@ return (
 
           <LogoLinksWrapper>
             <LogoLinks>
-              {web3Teams.map((team) => {
-                return (
-                  <a href={team.url} target="_blank" title={team.name} style={{ height: team.height }} key={team.name}>
-                    <Widget
-                      src="${REPL_MOB}/widget/Image"
-                      props={{
-                        image: returnIpfsImage(team.ipfsImage),
-                        alt: team.name,
-                      }}
-                    />
-                  </a>
-                );
-              })}
-            </LogoLinks>
-            <LogoLinks>
-              {web3Teams2.map((team) => {
-                return (
-                  <a href={team.url} target="_blank" title={team.name} style={{ height: team.height }} key={team.name}>
-                    <Widget
-                      src="${REPL_MOB}/widget/Image"
-                      props={{
-                        image: returnIpfsImage(team.ipfsImage),
-                        alt: team.name,
-                      }}
-                    />
-                  </a>
-                );
-              })}
+              {web3TeamsCombined.map((team) => (
+                <Link href={team.url} target="_blank" title={team.name} style={{ height: team.height }} key={team.name}>
+                  <Widget
+                    src="${REPL_MOB}/widget/Image"
+                    props={{
+                      image: returnIpfsImage(team.ipfsImage),
+                      alt: team.name,
+                    }}
+                  />
+                </Link>
+              ))}
             </LogoLinks>
           </LogoLinksWrapper>
         </Teams>


### PR DESCRIPTION
Closes #639 

Desktop:
<img width="1273" alt="Знімок екрана 2024-02-08 о 17 55 09" src="https://github.com/near/near-discovery-components/assets/34593263/10dc2b7f-d3f8-4e65-86d4-dcaab40fbda2">

Tablet:
<img width="770" alt="Знімок екрана 2024-02-08 о 17 55 27" src="https://github.com/near/near-discovery-components/assets/34593263/5c1609c8-c73f-4d14-8e2e-d50ff732640b">

Mobile:
<img width="391" alt="Знімок екрана 2024-02-08 о 17 55 48" src="https://github.com/near/near-discovery-components/assets/34593263/7c0ccdbb-08f8-40b8-8c59-d24068ec02fe">
