### PR TITLE
chore: refactor `NotificationButton`

### DIFF
--- a/src/NearOrg/Notifications/Notifications.jsx
+++ b/src/NearOrg/Notifications/Notifications.jsx
@@ -1,11 +1,6 @@
 let {
-  isLocalStorageSupported,
-  isNotificationSupported,
-  isPermisionGranted,
-  isPushManagerSupported,
   manageNotification,
   handleTurnOn,
-  handleOnCancel,
   getNotificationLocalStorage,
   handleOnCancelBanner,
   accountId,
@@ -15,6 +10,7 @@ let {
   iOSDevice,
   iOSVersion,
   recomendedIOSVersion,
+  moderatorAccount,
 } = props;
 
 showInBox = showInBox ?? false;
@@ -114,7 +110,7 @@ return (
     <NotificationsWrapper>
       <Widget
         src="${REPL_ACCOUNT}/widget/NearOrg.Notifications.NotificationsMiddleware"
-        props={{ showLimit, manageNotification, permission }}
+        props={{ showLimit, manageNotification, permission, moderatorAccount }}
       />
     </NotificationsWrapper>
   </Card>

--- a/src/NearOrg/Notifications/NotificationsList.jsx
+++ b/src/NearOrg/Notifications/NotificationsList.jsx
@@ -1,4 +1,5 @@
-let { fetchNotifications, shouldFallback, manageNotification, permission, showLimit } = props;
+let { fetchNotifications, shouldFallback, manageNotification, permission, showLimit, moderatorAccount } = props;
+moderatorAccount = moderatorAccount ?? "${REPL_MODERATOR}";
 // showLimit means to fetch notificaitions for the preview and not the full list
 
 const [notifications, setNotifications] = useState(notifications ?? []);
@@ -38,7 +39,7 @@ const NotificationsListFromChain = () => {
         renderItem,
         nextLimit: 10,
         initialRenderLimit: showLimit ?? 10,
-        moderatorAccount: "${REPL_MODERATOR}",
+        moderatorAccount,
       }}
     />
   );

--- a/src/NearOrg/Notifications/Preview.jsx
+++ b/src/NearOrg/Notifications/Preview.jsx
@@ -1,0 +1,80 @@
+let {
+  rootProps,
+  contentProps,
+  triggerProps,
+  disabled,
+  inline,
+  children,
+  viewMoreBtn,
+  viewMoreHref,
+  ...forwardedProps
+} = props;
+
+viewMoreHref = viewMoreHref ?? "/notifications";
+
+const TriggerWrapper = styled.span`
+  display: ${inline ? "inline-flex" : "flex"};
+  vertical-align: ${inline ? "baseline" : ""};
+  max-width: 100%;
+  white-space: normal;
+`;
+
+const PreviewWrapper = styled.div`
+  border-radius: 6px;
+  background: var(--white);
+  box-shadow:
+    0px 4px 8px 0px rgba(0, 0, 0, 0.06),
+    0px 0px 0px 1px rgba(0, 0, 0, 0.06);
+  width: 460px;
+  max-height: 80vh;
+  overflow: hidden auto;
+`;
+
+const PreviewContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const SeeAll = styled.div`
+  padding: 16px;
+
+  div {
+    width: 100%;
+  }
+`;
+
+const DefaultViewMoreBtn = () => (
+  <SeeAll>
+    <Widget
+      src="${REPL_ACCOUNT}/widget/DIG.Button"
+      props={{
+        href: viewMoreHref,
+        variant: "primary",
+        fill: "outline",
+        label: "See all",
+        size: "small",
+        style: {
+          width: "100%",
+        },
+      }}
+    />
+  </SeeAll>
+);
+
+return (
+  <HoverCard.Root openDelay={200} closeDelay={300} {...rootProps}>
+    <HoverCard.Trigger asChild>
+      <TriggerWrapper {...triggerProps}>{children || "Hover Me"}</TriggerWrapper>
+    </HoverCard.Trigger>
+    {!disabled && (
+      <HoverCard.Content asChild {...contentProps} side="bottom" sideOffset={10} hideWhenDetached={true}>
+        <PreviewWrapper>
+          <PreviewContent>
+            <Widget src="${REPL_ACCOUNT}/widget/NearOrg.Notifications.Notifications" props={{ ...forwardedProps }} />
+            {!viewMoreBtn && <DefaultViewMoreBtn />}
+          </PreviewContent>
+        </PreviewWrapper>
+      </HoverCard.Content>
+    )}
+  </HoverCard.Root>
+);


### PR DESCRIPTION
This PR introduces a couple of improvements:

1. Use [HoverCard](https://www.radix-ui.com/primitives/docs/components/hover-card) like it's already done for `AccountProfileOverlay` component;
2. Move notifications list preview to the separate component which gain us more control (like passing custom trigger component, etc);
3. Add `size` property to `NotificationsButton` component;
4. Delete unused variables;
5. Cleanup.

### This PR doesn't have braking change

Which means it can be promoted into production as well.