### PR TITLE
Container Refactor

### DIFF
--- a/src/ActivityPage.jsx
+++ b/src/ActivityPage.jsx
@@ -1,14 +1,13 @@
 const [selectedTab, setSelectedTab] = useState(props.tab ?? "posts");
-
-if (props.tab && props.tab !== selectedTab) {
-  setSelectedTab(props.tab);
-}
-
 const activityUrl = `/${REPL_ACCOUNT}/widget/ActivityPage`;
 
 const Wrapper = styled.div`
-  margin-top: calc(var(--body-top-padding) * -1);
-  padding-bottom: 48px;
+  padding-top: 0;
+
+  @media (max-width: 1024px) {
+    padding-left: 0;
+    padding-right: 0;
+  }
 `;
 
 const Main = styled.div`
@@ -23,8 +22,8 @@ const Main = styled.div`
 
 const Section = styled.div`
   padding-top: 24px;
-  border-left: ${(p) => (p.primary ? "1px solid #ECEEF0" : "none")};
-  border-right: ${(p) => (p.primary ? "1px solid #ECEEF0" : "none")};
+  border-left: ${(p) => (p.$primary ? "1px solid #ECEEF0" : "none")};
+  border-right: ${(p) => (p.$primary ? "1px solid #ECEEF0" : "none")};
 
   > div {
     padding-bottom: 24px;
@@ -42,8 +41,8 @@ const Section = styled.div`
     padding-top: 0px;
     border-left: none;
     border-right: none;
-    display: ${(p) => (p.active ? "block" : "none")};
-    margin: ${(p) => (p.negativeMargin ? "0 -12px" : "0")};
+    display: ${(p) => (p.$active ? "block" : "none")};
+    padding: ${(p) => p.$smallScreenPadding};
   }
 `;
 
@@ -52,14 +51,11 @@ const Tabs = styled.div`
   height: 48px;
   background: #f8f9fa;
   border-bottom: 1px solid #eceef0;
-  margin-bottom: ${(p) => (p.noMargin ? "0" : p.halfMargin ? "24px" : "24px")};
   overflow: auto;
   scroll-behavior: smooth;
 
   @media (max-width: 1024px) {
     display: flex;
-    margin-left: -12px;
-    margin-right: -12px;
 
     > * {
       flex: 1;
@@ -76,7 +72,7 @@ const TabsButton = styled("Link")`
   font-size: 12px;
   padding: 0 12px;
   position: relative;
-  color: ${(p) => (p.selected ? "#11181C" : "#687076")};
+  color: ${(p) => (p.$selected ? "#11181C" : "#687076")};
   background: none;
   border: none;
   outline: none;
@@ -89,7 +85,7 @@ const TabsButton = styled("Link")`
 
   &::after {
     content: "";
-    display: ${(p) => (p.selected ? "block" : "none")};
+    display: ${(p) => (p.$selected ? "block" : "none")};
     position: absolute;
     bottom: 0;
     left: 0;
@@ -100,11 +96,11 @@ const TabsButton = styled("Link")`
 `;
 
 return (
-  <Wrapper className="container-xl" negativeMargin={selectedTab === "posts"}>
-    <Tabs halfMargin={selectedTab === "apps"} noMargin={selectedTab === "posts"}>
+  <Wrapper className="gateway-page-container">
+    <Tabs>
       <TabsButton
         href={`${activityUrl}?tab=posts`}
-        selected={selectedTab === "posts"}
+        $selected={selectedTab === "posts"}
         onClick={() => setSelectedTab("posts")}
       >
         Posts
@@ -112,7 +108,7 @@ return (
 
       <TabsButton
         href={`${activityUrl}?tab=apps`}
-        selected={selectedTab === "apps"}
+        $selected={selectedTab === "apps"}
         onClick={() => setSelectedTab("apps")}
       >
         Components
@@ -120,7 +116,7 @@ return (
 
       <TabsButton
         href={`${activityUrl}?tab=explore`}
-        selected={selectedTab === "explore"}
+        $selected={selectedTab === "explore"}
         onClick={() => setSelectedTab("explore")}
       >
         Explore
@@ -128,16 +124,16 @@ return (
     </Tabs>
 
     <Main>
-      <Section active={selectedTab === "apps"}>
+      <Section $smallScreenPadding="1rem" $active={selectedTab === "apps"}>
         <Widget src="${REPL_ACCOUNT}/widget/FeaturedComponents" />
         <Widget src="${REPL_ACCOUNT}/widget/LatestComponents" />
       </Section>
 
-      <Section negativeMargin primary active={selectedTab === "posts"}>
+      <Section $smallScreenPadding="0" $primary $active={selectedTab === "posts"}>
         <Widget src={`${REPL_ACCOUNT}/widget/ActivityFeeds.DetermineActivityFeed`} />
       </Section>
 
-      <Section active={selectedTab === "explore"}>
+      <Section $smallScreenPadding="1rem" $active={selectedTab === "explore"}>
         <Widget src="${REPL_ACCOUNT}/widget/ExploreWidgets" />
       </Section>
     </Main>

--- a/src/ComponentDetailsPage.jsx
+++ b/src/ComponentDetailsPage.jsx
@@ -29,9 +29,9 @@ const Text = styled.p`
   margin: 0;
   font-size: 14px;
   line-height: 20px;
-  color: ${(p) => (p.bold ? "#11181C" : "#687076")};
-  font-weight: ${(p) => (p.bold ? "600" : "400")};
-  font-size: ${(p) => (p.small ? "12px" : "14px")};
+  color: ${(p) => (p.$bold ? "#11181C" : "#687076")};
+  font-weight: ${(p) => (p.$bold ? "600" : "400")};
+  font-size: ${(p) => (p.$small ? "12px" : "14px")};
 
   i {
     margin-right: 4px;
@@ -65,7 +65,7 @@ const TabsButton = styled("Link")`
   font-size: 12px;
   padding: 0 12px;
   position: relative;
-  color: ${(p) => (p.selected ? "#11181C" : "#687076")};
+  color: ${(p) => (p.$selected ? "#11181C" : "#687076")};
   background: none;
   border: none;
   outline: none;
@@ -78,7 +78,7 @@ const TabsButton = styled("Link")`
 
   &::after {
     content: "";
-    display: ${(p) => (p.selected ? "block" : "none")};
+    display: ${(p) => (p.$selected ? "block" : "none")};
     position: absolute;
     bottom: 0;
     left: 0;
@@ -111,7 +111,7 @@ const Icon = styled.i`
 if (!exists) {
   return (
     <>
-      <Text bold>Error</Text>
+      <Text $bold>Error</Text>
       <Text>Could not find: {src}</Text>
     </>
   );
@@ -122,7 +122,7 @@ if (tab && tab !== selectedTab) {
 }
 
 return (
-  <Wrapper>
+  <Wrapper className="gateway-page-container">
     <Widget
       src="${REPL_ACCOUNT}/widget/ComponentSummary"
       props={{
@@ -135,15 +135,15 @@ return (
     />
 
     <Tabs>
-      <TabsButton href={`${detailsUrl}&tab=source`} selected={selectedTab === "source"}>
+      <TabsButton href={`${detailsUrl}&tab=source`} $selected={selectedTab === "source"}>
         <Icon className="ph ph-code" />
         Source & Preview
       </TabsButton>
-      <TabsButton href={`${detailsUrl}&tab=about`} selected={selectedTab === "about"}>
+      <TabsButton href={`${detailsUrl}&tab=about`} $selected={selectedTab === "about"}>
         <Icon className="ph ph-file-text" />
         Read.me
       </TabsButton>
-      <TabsButton href={`${detailsUrl}&tab=discussion`} selected={selectedTab === "discussion"}>
+      <TabsButton href={`${detailsUrl}&tab=discussion`} $selected={selectedTab === "discussion"}>
         <Icon className="ph ph-chat-circle-text" />
         Discussion
       </TabsButton>

--- a/src/ComponentsPage.jsx
+++ b/src/ComponentsPage.jsx
@@ -62,8 +62,6 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 48px;
-  padding-bottom: 48px;
-  padding-top: 48px;
 `;
 
 const Header = styled.div`
@@ -99,12 +97,12 @@ const H2 = styled.h2`
 const Text = styled.p`
   margin: 0;
   line-height: 1.5rem;
-  color: ${(p) => (p.bold ? "#11181C" : "#687076")} !important;
-  font-weight: ${(p) => (p.bold ? "600" : "400")};
-  font-size: ${(p) => (p.small ? "12px" : "14px")};
-  overflow: ${(p) => (p.ellipsis ? "hidden" : "")};
-  text-overflow: ${(p) => (p.ellipsis ? "ellipsis" : "")};
-  white-space: ${(p) => (p.ellipsis ? "nowrap" : "")};
+  color: ${(p) => (p.$bold ? "#11181C" : "#687076")} !important;
+  font-weight: ${(p) => (p.$bold ? "600" : "400")};
+  font-size: ${(p) => (p.$small ? "12px" : "14px")};
+  overflow: ${(p) => (p.$ellipsis ? "hidden" : "")};
+  text-overflow: ${(p) => (p.$ellipsis ? "ellipsis" : "")};
+  white-space: ${(p) => (p.$ellipsis ? "nowrap" : "")};
   overflow-wrap: anywhere;
 
   b {
@@ -168,8 +166,8 @@ const Tabs = styled.div`
   @media (max-width: 1024px) {
     background: #f8f9fa;
     border-top: 1px solid #eceef0;
-    margin-left: -12px;
-    margin-right: -12px;
+    margin-left: calc(var(--gateway-page-container-padding-x) * -1);
+    margin-right: calc(var(--gateway-page-container-padding-x) * -1);
 
     > * {
       flex: 1;
@@ -186,7 +184,7 @@ const TabsButton = styled("Link")`
   font-size: 12px;
   padding: 0 12px;
   position: relative;
-  color: ${(p) => (p.selected ? "#11181C" : "#687076")};
+  color: ${(p) => (p.$selected ? "#11181C" : "#687076")};
   background: none;
   border: none;
   outline: none;
@@ -199,7 +197,7 @@ const TabsButton = styled("Link")`
 
   &::after {
     content: "";
-    display: ${(p) => (p.selected ? "block" : "none")};
+    display: ${(p) => (p.$selected ? "block" : "none")};
     position: absolute;
     bottom: 0;
     left: 0;
@@ -210,7 +208,7 @@ const TabsButton = styled("Link")`
 `;
 
 return (
-  <Wrapper className="container-xl">
+  <Wrapper className="gateway-page-container">
     <Header>
       {state.selectedTab === "apps" && (
         <>
@@ -241,11 +239,11 @@ return (
 
     {!state.searchResults && (
       <Tabs>
-        <TabsButton href={`${componentsUrl}?tab=all`} selected={state.selectedTab === "all"}>
+        <TabsButton href={`${componentsUrl}?tab=all`} $selected={state.selectedTab === "all"}>
           All
         </TabsButton>
 
-        <TabsButton href={`${componentsUrl}?tab=apps`} selected={state.selectedTab === "apps"}>
+        <TabsButton href={`${componentsUrl}?tab=apps`} $selected={state.selectedTab === "apps"}>
           Apps
         </TabsButton>
       </Tabs>

--- a/src/Entities/Template/EntityList.jsx
+++ b/src/Entities/Template/EntityList.jsx
@@ -42,8 +42,6 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 48px;
-  padding-bottom: 48px;
-  padding-top: 48px;
 `;
 
 const Header = styled.div`
@@ -118,7 +116,7 @@ const ScrollBox = styled.div`
 `;
 
 return (
-  <Wrapper className="container-xl">
+  <Wrapper className="gateway-page-container">
     <Header>
       <div className="row">
         <div className="col">

--- a/src/NearOrg/CookiePrompt.jsx
+++ b/src/NearOrg/CookiePrompt.jsx
@@ -7,7 +7,8 @@ const Cookies = styled.div`
   background-color: white;
   border-radius: 4px;
   margin: 8px auto;
-  max-width: 50%;
+  max-width: 100%;
+  width: 714px;
   padding: 12px;
   display: flex;
   gap: 10px;
@@ -25,9 +26,12 @@ const Cookies = styled.div`
     gap: 10px;
   }
 
-  @media only screen and (max-width: 800px) {
+  @media (max-width: 800px) {
     flex-direction: column;
     align-items: flex-start;
+    margin: 0;
+    border-radius: 0;
+    width: 100%;
   }
 `;
 

--- a/src/NearOrg/Ecosystem/CommunityPage.jsx
+++ b/src/NearOrg/Ecosystem/CommunityPage.jsx
@@ -211,7 +211,7 @@ const connectChannelsLinks = [
 
 return (
   <>
-    <Wrapper className="container-xl">
+    <Wrapper className="gateway-page-container">
       <Section>
         <Flex gap="16px" direction="column" alignItems="start">
           <H1>Community</H1>

--- a/src/NearOrg/Ecosystem/GetFundingPage.jsx
+++ b/src/NearOrg/Ecosystem/GetFundingPage.jsx
@@ -357,7 +357,7 @@ const fundingHugeCards = [
 
 return (
   <>
-    <Wrapper className="container-xl">
+    <Wrapper className="gateway-page-container">
       <Section center>
         <Flex gap="16px" direction="column" alignItems="center">
           <H1>Get Funded. Build the Future.</H1>
@@ -381,7 +381,6 @@ return (
             props={{
               image: returnIpfsImage(ipfsImages.arrows),
               className: "img-fluid d-none d-lg-block mx-auto",
-              style: { maxWidth: "1000px" },
             }}
           />
           <div className="row row-cols-lg-4 row-cols-md-2 row-cols-1 g-4">

--- a/src/NearOrg/Ecosystem/OverviewPage.jsx
+++ b/src/NearOrg/Ecosystem/OverviewPage.jsx
@@ -407,7 +407,7 @@ const nearHubsCards = [
 
 return (
   <>
-    <Wrapper className="container-xl">
+    <Wrapper className="gateway-page-container">
       <Section center style={{ position: "relative" }}>
         <Flex gap="16px" direction="column" alignItems="center">
           <H1>Building the Open Web together</H1>

--- a/src/NearOrg/Ecosystem/WorkAndEarnPage.jsx
+++ b/src/NearOrg/Ecosystem/WorkAndEarnPage.jsx
@@ -85,7 +85,7 @@ const SocialIcon = styled.i`
 
 return (
   <>
-    <Wrapper className="container-xl">
+    <Wrapper className="gateway-page-container">
       <Section>
         <Flex gap="16px" direction="column" alignItems="start">
           <H1>Work & Earn</H1>

--- a/src/NearOrg/Notifications/Notifications.jsx
+++ b/src/NearOrg/Notifications/Notifications.jsx
@@ -17,7 +17,7 @@ showInBox = showInBox ?? false;
 
 const Header = styled.div`
   display: flex;
-  padding: ${(props) => (props.showInBox ? "16px 16px 16px 24px" : "48px 16px 24px 16px")};
+  padding: ${(props) => (props.showInBox ? "16px 16px 16px 24px" : "24px 16px 24px 16px")};
   align-items: center;
   align-self: stretch;
 `;
@@ -75,7 +75,7 @@ const checkShowBanner = () => {
 };
 
 return (
-  <Card className={showInBox ? "" : "container-xl"} showInBox={showInBox}>
+  <Card className={showInBox ? "" : "gateway-page-container"} showInBox={showInBox}>
     <Header showInBox={showInBox}>
       <Title>Notifications</Title>
       <Widget

--- a/src/NearOrg/Notifications/Settings.jsx
+++ b/src/NearOrg/Notifications/Settings.jsx
@@ -20,10 +20,7 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding-bottom: 48px;
-  padding-top: 48px;
   max-width: 592px;
-  margin: 0 auto;
 `;
 
 const Text = styled.div`
@@ -77,7 +74,7 @@ const checkShow = () => {
 };
 
 return (
-  <Wrapper className="container-xl">
+  <Wrapper className="gateway-page-container">
     <Widget
       src="${REPL_ACCOUNT}/widget/NearOrg.Notifications.SettingsHeader"
       props={{

--- a/src/NearOrg/PrivacyPage.jsx
+++ b/src/NearOrg/PrivacyPage.jsx
@@ -25,13 +25,13 @@ if (!privacy) {
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: ${(p) => !p.compact && "18px"};
-  padding-bottom: ${(p) => !p.compact && "48px"};
-  padding-top: ${(p) => !p.compact && "48px"};
+  gap: ${(p) => (p.$compact ? 0 : "18px")};
+  padding-bottom: ${(p) => (p.$compact ? 0 : undefined)};
+  padding-top: ${(p) => (p.$compact ? 0 : undefined)};
 `;
 
 return (
-  <Wrapper className="container-xl" compact={compact}>
+  <Wrapper className="gateway-page-container" $compact={compact}>
     <Markdown text={privacy} />
   </Wrapper>
 );

--- a/src/NearOrg/TermsPage.jsx
+++ b/src/NearOrg/TermsPage.jsx
@@ -25,13 +25,13 @@ if (!terms) {
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: ${(p) => !p.compact && "18px"};
-  padding-bottom: ${(p) => !p.compact && "48px"};
-  padding-top: ${(p) => !p.compact && "48px"};
+  gap: ${(p) => (p.$compact ? 0 : "18px")};
+  padding-bottom: ${(p) => (p.$compact ? 0 : undefined)};
+  padding-top: ${(p) => (p.$compact ? 0 : undefined)};
 `;
 
 return (
-  <Wrapper className="container-xl" compact={compact}>
+  <Wrapper className="gateway-page-container" $compact={compact}>
     <Markdown text={terms} />
   </Wrapper>
 );

--- a/src/NearOrg/UsePage.jsx
+++ b/src/NearOrg/UsePage.jsx
@@ -206,7 +206,7 @@ const UseCase = styled.div`
 
 return (
   <>
-    <Wrapper className="container-xl">
+    <Wrapper className="gateway-page-container">
       <Section center>
         <H1>Your first steps to becoming a Web3 citizen</H1>
       </Section>

--- a/src/PeoplePage.jsx
+++ b/src/PeoplePage.jsx
@@ -73,8 +73,6 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 48px;
-  padding-bottom: 48px;
-  padding-top: 48px;
 `;
 
 const Header = styled.div`
@@ -221,7 +219,7 @@ const TabsButton = styled("Link")`
 `;
 
 return (
-  <Wrapper className="container-xl">
+  <Wrapper className="gateway-page-container">
     <Header>
       <H1>{totalAccounts} People</H1>
       <H2>Connect with the NEAR community.</H2>

--- a/src/Settings/Index.jsx
+++ b/src/Settings/Index.jsx
@@ -47,7 +47,7 @@ const Sidebar = () => (
 );
 
 return (
-  <Wrapper className="container-xl">
+  <Wrapper className="gateway-page-container">
     <SettingsContent />
   </Wrapper>
 );


### PR DESCRIPTION
Closes: https://github.com/near/near-discovery-components/issues/710

- Swap out all usage of `container-xl` for `gateway-page-container`
- Refactored a few Styled Components props to use `$` prefix to get the ball rolling

This gateway PR is what introduces the new `gateway-page-container` class: https://github.com/near/near-discovery/pull/1069 - we'll want to try and merge/deploy both of these PR's at the same time for production. Otherwise, some of our pages will render without being properly centered.