### PR TITLE
fix: broken devhub notifications

### DIFF
--- a/src/NearOrg/Notifications/NotificationsMiddleware.jsx
+++ b/src/NearOrg/Notifications/NotificationsMiddleware.jsx
@@ -1,5 +1,7 @@
 const { fetchGraphQL, loadItems } = VM.require("${REPL_ACCOUNT}/widget/Entities.QueryApi.Client") || (() => {});
 
+const accountId = context.accountId;
+
 const [shouldFallback, setShouldFallback] = useState(false);
 
 const lastNotificationQuery = `
@@ -13,7 +15,7 @@ const lastNotificationQuery = `
 const notificationsQuery = `query NotificationsQuery($offset: Int, $limit: Int) {
   data: dataplatform_near_notifications_notifications(
     distinct_on: [blockHeight, initiatedBy],
-    where: {receiver: {_eq: "${context.accountId}"}}
+    where: {receiver: {_eq: "${accountId}"}}
     order_by: [{blockHeight: desc}, {initiatedBy:asc}],
     offset: $offset, limit: $limit
   ) {
@@ -35,7 +37,7 @@ const notificationsQuery = `query NotificationsQuery($offset: Int, $limit: Int) 
   }
   count: dataplatform_near_notifications_notifications_aggregate(
     distinct_on: [blockHeight, initiatedBy],
-    where: {receiver: {_eq: "${context.accountId}"}}
+    where: {receiver: {_eq: "${accountId}"}}
   ) {
     aggregate {
       count
@@ -43,7 +45,7 @@ const notificationsQuery = `query NotificationsQuery($offset: Int, $limit: Int) 
   }
 }`;
 
-const lastNotificationOnChain = Social.index("notify", context.accountId, {
+const lastNotificationOnChain = Social.index("notify", accountId, {
   limit: 1,
   order: "desc",
 });
@@ -67,8 +69,8 @@ const fetchNotifications = (offset, limit, saveData) => {
             value: {
               item: {
                 blockHeight: notification?.actionAtBlockHeight,
-                path: notification.path,
-                type: notification.itemType,
+                path: notification?.path,
+                type: notification?.itemType,
               },
               type: notification.valueType,
               message: notification.message,


### PR DESCRIPTION
This PR introduces an extra check for notification `value` param which needed to show notification properly. 

### Why do we need this check?

Well, we query for the notification data using queryApi. This means some params could be missed because of some new notification type or because the data itself has been created long time ago and indexer didn't collected them. That's why some notifications could be hidden for user or some parts of notification might not exist (as notification preview for example or entire `custom` notification).

### Solution

Each notification type has required amount of params which needed to create a human readable message. So, I've added a method to check whatever a notification value (from QueryAPI) contain all the needed params. This check method depends on type of notification (this param comes from QueryAPI all the time. I believe so 🙂) If the notification does not have a certain value necessary for its display, we make a `Social.get()` request (the same as we have before QueryAPI implementation).

Closes #717 