### PR TITLE
feat: entity namespaces and stars

### DIFF
--- a/indexers/agents/agents.js
+++ b/indexers/agents/agents.js
@@ -1,3 +1,4 @@
+// deprecated, delete once agiguild nexus is live
 import { Block } from "@near-lake/primitives";
 /**
  * Note: We only support javascript at the moment. We will support Rust, Typescript in a further release.

--- a/indexers/entities/entities.js
+++ b/indexers/entities/entities.js
@@ -1,0 +1,175 @@
+import { Block } from "@near-lake/primitives";
+/**
+ * Note: We only support javascript at the moment. We will support Rust, Typescript in a further release.
+ */
+
+/**
+ * getBlock(block, context) applies your custom logic to a Block on Near and commits the data to a database.
+ * context is a global variable that contains helper methods.
+ * context.db is a subfield which contains helper methods to interact with your database.
+ *
+ * Learn more about indexers here:  https://docs.near.org/concepts/advanced/indexers
+ *
+ * @param {block} Block - A Near Protocol Block
+ */
+async function getBlock(block: Block) {
+    function base64decode(encodedValue) {
+        try {
+            const buff = Buffer.from(encodedValue, "base64");
+            const str = buff.toString("utf-8").replace(/\\xa0/g, " ");
+            return JSON.parse(str);
+        } catch (error) {
+            console.log(
+                'Error parsing JSON - skipping data for "functionCallOperation.args"',
+                error
+            );
+        }
+    }
+
+    const getFunctionCallsFunction = (block, contract, method) => {
+        return block
+            .actions()
+            .filter((action) => action.receiverId === contract)
+            .flatMap((action) =>
+                action.operations
+                    .map((operation) => operation["FunctionCall"])
+                    .filter((operation) => operation?.methodName === method)
+                    .map((functionCallOperation) => ({
+                        ...functionCallOperation,
+                        args: base64decode(functionCallOperation.args),
+                        receiptId: action.receiptId,
+                    }))
+                    .filter((a) =>
+                        block
+                            .receipts()
+                            .find((r) => r.receiptId === a.receiptId)
+                            .status.hasOwnProperty("SuccessValue")
+                    )
+            );
+    };
+
+    const getSocialOperations = (block, operation) => {
+        const contract = "social.near";
+        const method = "set";
+        return getFunctionCallsFunction(block, contract, method)
+            .filter((functionCall) => {
+                if (
+                    !functionCall ||
+                    !functionCall.args ||
+                    !functionCall.args.data ||
+                    !Object.keys(functionCall.args.data) ||
+                    !Object.keys(functionCall.args.data)[0]
+                ) {
+                    console.log("Set operation did not have arg data in expected format");
+                    return;
+                }
+                const accountId = Object.keys(functionCall.args.data)[0];
+                const accountData = functionCall.args.data[accountId];
+                if (!accountData) {
+                    console.log(
+                        "Set operation did not have arg data for accountId in expected format"
+                    );
+                    return;
+                }
+                return accountData[operation];
+            })
+            .map((functionCall) => {
+                const accountId = Object.keys(functionCall.args.data)[0];
+                return {
+                    accountId,
+                    data: functionCall.args.data[accountId][operation],
+                };
+            });
+    };
+
+    const entityWrites = getSocialOperations(block, "entities");
+    await entityWrites.map(async ({ accountId, data }) => {
+        try {
+            const namespaces = Object.keys(data);
+            namespaces.map(async (namespace) => {
+                const namespaceData = data[namespace];
+                const entityTypes = Object.keys(namespaceData);
+                entityTypes.map(async (entityType) => {
+                    const entityTypeData = namespaceData[entityType];
+                    const entities = Object.keys(entityTypeData);
+                    entities.map(async (name) => {
+                        const entityProps = entityTypeData[name];
+                        const { displayName, logoUrl, ...entityAttributes } = entityProps;
+                        const entity = {
+                            namespace: namespace,
+                            entity_type: entityType,
+                            account_id: accountId,
+                            name: name,
+                            display_name: displayName,
+                            logo_url: logoUrl,
+                            attributes: entityAttributes,
+                        };
+                        await context.db.Entities.upsert(
+                            entity,
+                            ["entity_type", "account_id", "name"],
+                            ["display_name", "logo_url", "attributes"]
+                        );
+
+                        console.log(
+                            `${entityType} from ${accountId} has been added to the database`
+                        );
+                    });
+                });
+            });
+        } catch (e) {
+            console.log(
+                `Failed to store entity from ${accountId} to the database`,
+                e
+            );
+        }
+    });
+
+    const indexOps = getSocialOperations(block, "index");
+    await indexOps
+        .filter(({ accountId, data }) => {
+            const type = "star";
+            return data[type];
+        })
+        .map(async ({ accountId, data }) => {
+            try {
+            const type = "star";
+            const starData = data[type];
+            if (!starData) {
+                console.log("No star data found");
+                return;
+            }
+            const star = JSON.parse(starData);
+            // "{\"key\":{\"type\":\"social\",\"path\":\"flatirons.near/examples/favoriteCar/delorean\"},\"value\":{\"type\":\"star\"}}"
+            const starArray = typeof star === "object" ? [star] : star;
+            starArray.map(async ({ key, value }) => {
+                if (!key || !value || !key.path || !value.type) {
+                    console.log("Required fields not found for star", key, value);
+                    return;
+                }
+                const { path } = key;
+                const { type } = value;
+                const [targetAccountId, entitiesConstant, namespace, entityType, name] = path.split("/");
+                const incDecQuery = `
+                mutation ChangeStars {
+                  update_dataplatform_near_entities_entities(
+                    where: {namespace: {_eq: "${namespace}"}, entity_type: {_eq: "${entityType}"}, 
+                    account_id: {_eq: "${targetAccountId}"}, name: {_eq: "${name}"}},
+                    _inc: {stars: ${type === "star" ? 1 : -1}}
+                  ) {
+                    affected_rows
+                    returning { account_id namespace entity_type name stars }
+                  }
+                }
+                `;
+                console.log("mutation is", incDecQuery);
+                await context.graphql(incDecQuery, {});
+            });
+            } catch (e) {
+                console.log(
+                    `Failed to process star of entity from ${accountId} to the database`,
+                    e
+                );
+            }
+
+        });
+}

--- a/indexers/entities/entities.sql
+++ b/indexers/entities/entities.sql
@@ -1,35 +1,14 @@
--- deprecated, delete once agiguild nexus is live
-
-CREATE TABLE
-    "agents" (
-                 "id" SERIAL NOT NULL,
-                 "account_id" TEXT NOT NULL,
-                 "name" TEXT NOT NULL,
-                 "display_name" TEXT,
-                 "preferred_provider" TEXT,
-                 "preferred_model" TEXT,
-                 "input_adaptor" TEXT,
-                 "output_adaptor" TEXT,
-                 "prompt" TEXT,
-                 "variables" TEXT,
-                 "component" TEXT,
-                 "logo_url" TEXT,
-                 "tools" JSONB,
-                 "properties" JSONB,
-                 PRIMARY KEY ("id")
-);
-
-ALTER TABLE "agents" ADD CONSTRAINT "unique_name" UNIQUE ("account_id", "name");
-
 -- commented lines are features that are not supported by context.db but are in the table
 -- that was created in the db
 CREATE TABLE "entities"
 (
     "id" SERIAL NOT NULL,
+    "namespace"   TEXT NOT NULL,
     "entity_type"  TEXT NOT NULL,
     "account_id"   TEXT NOT NULL,
     "name"         TEXT NOT NULL,
     "display_name" TEXT,
+    "description"  TEXT,
     "logo_url"     TEXT,
     "attributes"   JSONB,
     "stars"        integer, -- default 0

--- a/src/Entities/Examples/ComponentSchema.jsx
+++ b/src/Entities/Examples/ComponentSchema.jsx
@@ -1,0 +1,53 @@
+const genSchema = (namespace, entityType) => {
+  const title = "Component";
+  return {
+    namespace: namespace,
+    entityType: entityType,
+    entityTitle: title,
+    id: {
+      type: "integer",
+      displayType: "hidden",
+    },
+    accountId: {
+      type: "text",
+      displayType: "hidden",
+    },
+    name: {
+      type: "string",
+      inputProps: {
+        min: 2,
+        max: 80,
+        allowCommaAndSpace: false,
+        placeholder: `Choose a unique identifier for your ${title}.`,
+        required: true,
+      },
+      label: "Name",
+      order: 1,
+    },
+    displayName: {
+      type: "string",
+      inputProps: {
+        min: 2,
+        max: 255,
+        placeholder: "The name that will be displayed to users.",
+        required: true,
+      },
+      label: "Display Name",
+      order: 2,
+    },
+    logoUrl: {
+      type: "string",
+      inputProps: {
+        min: 4,
+        max: 255,
+        placeholder: `The logo URL for the ${title}.`,
+        required: false,
+      },
+
+      label: "Logo URL",
+      order: 5,
+    },
+  };
+};
+
+return { genSchema };

--- a/src/Entities/Examples/ComponentsPage.jsx
+++ b/src/Entities/Examples/ComponentsPage.jsx
@@ -5,12 +5,23 @@
 //    You'll need to create a <Entity>Page but can reuse EntityList, EntityCreate
 // The entity type in this example is 'components'
 
-const entityType = "Component";
+const { href } = VM.require("${REPL_DEVHUB}/widget/core.lib.url");
+if (!href) {
+  return <></>;
+}
+const { genSchema } = VM.require(`${REPL_ACCOUNT}/widget/Entities.Examples.ComponentSchema`);
+if (!genSchema) {
+  return <></>;
+}
+const schema = genSchema("", "component");
+
+const entityType = "component";
 const entityIndexer = "components";
 const entityTable = "metadata";
 
 const user = "dataplatform_near";
 const collection = `${user}_${entityIndexer}_${entityTable}`;
+
 const buildQueries = (searchKey, sort) => {
   const queryFilter = searchKey ? `name: {_ilike: "%${searchKey}%"}` : "";
   let querySortOption = "";
@@ -57,7 +68,7 @@ query ListQuery($offset: Int, $limit: Int) {
 };
 const queryName = "ListQuery";
 
-const renderItem = (item) => {
+const renderItem = (item, editFunction) => {
   return (
     <Widget
       src="${REPL_ACCOUNT}/widget/ComponentCard"
@@ -71,6 +82,6 @@ const renderItem = (item) => {
 return (
   <Widget
     src="${REPL_ACCOUNT}/widget/Entities.Template.EntityList"
-    props={{ entityType, buildQueries, queryName, collection, renderItem }}
+    props={{ loadItems, buildQueries, queryName, collection, renderItem, createWidget, schema }}
   />
 );

--- a/src/Entities/Examples/FavoriteCarSchema.jsx
+++ b/src/Entities/Examples/FavoriteCarSchema.jsx
@@ -1,0 +1,85 @@
+const genSchema = (namespace, entityType) => {
+  const title = "Favorite Car";
+  return {
+    namespace: namespace,
+    entityType: entityType,
+    entityTitle: title,
+    id: {
+      type: "integer",
+      displayType: "hidden",
+    },
+    accountId: {
+      type: "text",
+      displayType: "hidden",
+    },
+    name: {
+      type: "string",
+      inputProps: {
+        min: 2,
+        max: 80,
+        allowCommaAndSpace: false,
+        placeholder: `Choose a unique identifier for your ${title}.`,
+        required: true,
+      },
+      label: "Name",
+      order: 1,
+    },
+    displayName: {
+      type: "string",
+      inputProps: {
+        min: 2,
+        max: 255,
+        placeholder: "The name that will be displayed to users.",
+        required: true,
+      },
+      label: "Display Name",
+      order: 2,
+    },
+    logoUrl: {
+      type: "string",
+      inputProps: {
+        min: 4,
+        max: 255,
+        placeholder: `An image of your ${title}.`,
+        required: false,
+      },
+
+      label: "Logo URL",
+      order: 5,
+    },
+    make: {
+      type: "string",
+      inputProps: {
+        min: 2,
+        max: 80,
+        placeholder: `Make of your ${title}.`,
+        required: true,
+      },
+      label: "Make",
+      order: 6,
+    },
+    model: {
+      type: "string",
+      inputProps: {
+        min: 2,
+        max: 80,
+        placeholder: `Model of your ${title}.`,
+        required: true,
+      },
+      label: "Model",
+      order: 7,
+    },
+    color: {
+      type: "string",
+      inputProps: {
+        min: 2,
+        max: 80,
+        placeholder: `Blue, red, dragon wrap?`,
+      },
+      label: "Color",
+      order: 8,
+    },
+  };
+};
+
+return { genSchema };

--- a/src/Entities/Examples/FavoriteCars.jsx
+++ b/src/Entities/Examples/FavoriteCars.jsx
@@ -1,0 +1,15 @@
+return (
+  <>
+    <p>A custom message</p>
+    <Widget
+      src="${REPL_ACCOUNT}/widget/Entities.Template.GenericEntityConfig"
+      props={{
+        namespace: "examples",
+        entityType: "favoriteCar",
+        title: "Favorite Car",
+        schemaFile: "${REPL_ACCOUNT}/widget/Entities.Examples.FavoriteCarSchema",
+        //todo defaultImage: "some car photo",
+      }}
+    />
+  </>
+);

--- a/src/Entities/Examples/FavoritePlaces.jsx
+++ b/src/Entities/Examples/FavoritePlaces.jsx
@@ -1,0 +1,6 @@
+return (
+  <Widget
+    src="${REPL_ACCOUNT}/widget/Entities.Template.GenericEntityConfig"
+    props={{ namespace: "examples", entityType: "favoritePlace", title: "Favorite Place" }}
+  />
+);

--- a/src/Entities/Template/EntityCreate.jsx
+++ b/src/Entities/Template/EntityCreate.jsx
@@ -15,8 +15,9 @@ const namespace = schema.namespace;
 const onSubmitDefault = (formValues) => {
   const { name, ...rest } = formValues;
   const entity = { [name]: rest };
-  const data = namespace ? { [namespace]: { [entityType]: entity } } : { [entityType]: entity };
-  Social.set(data, { force: true });
+  const ns = namespace ? namespace : "default";
+  const data = { [ns]: { [entityType]: entity } };
+  Social.set({ entities: data }, { force: true });
 };
 const onSubmitFunction = onSubmit ?? onSubmitDefault;
 

--- a/src/Entities/Template/EntityDetails.jsx
+++ b/src/Entities/Template/EntityDetails.jsx
@@ -6,7 +6,6 @@ let { src, tab, highlightComment, schemaFile, namespace } = props;
 const [accountId, entityType, entityName] = src.split("/") ?? [null, null, null];
 
 let entity = Social.get(`${accountId}/entities/${namespace}/${entityType}/${entityName}/**`);
-console.log("entity", `${accountId}/${namespace}/${entityType}/${entityName}/**`, entity);
 const exists = !existsData || Object.keys(existsData).length > 0;
 if (!exists) {
   return (

--- a/src/Entities/Template/EntityDetails.jsx
+++ b/src/Entities/Template/EntityDetails.jsx
@@ -5,7 +5,8 @@ if (!href) {
 let { src, tab, highlightComment, schemaFile, namespace } = props;
 const [accountId, entityType, entityName] = src.split("/") ?? [null, null, null];
 
-let entity = Social.get(`${accountId}/${namespace}/${entityType}/${entityName}/**`);
+let entity = Social.get(`${accountId}/entities/${namespace}/${entityType}/${entityName}/**`);
+console.log("entity", `${accountId}/${namespace}/${entityType}/${entityName}/**`, entity);
 const exists = !existsData || Object.keys(existsData).length > 0;
 if (!exists) {
   return (
@@ -24,7 +25,7 @@ if (!genSchema) {
 const schema = genSchema(namespace, entityType);
 const { title } = schema;
 
-entity = { accountId, name: entityName, ...entity };
+entity = { accountId, namespace: namespace, entityType: entityType, name: entityName, ...entity };
 const { prompt } = entity;
 const editType = accountId === context.accountId ? "edit" : "fork";
 const editLabel = editType === "edit" ? "Edit" : "Fork";
@@ -75,10 +76,10 @@ const PropValue = styled.p`
   padding-bottom: 10px;
 `;
 const entityProperties = (obj) => {
-  const { accountId, name, displayName, logoUrl, ...displayProps } = obj;
+  const { accountId, name, displayName, logoUrl, namespace, entityType, ...attributes } = obj;
   return (
     <>
-      {Object.keys(displayProps).map((k) => (
+      {Object.keys(attributes).map((k) => (
         <>
           <Text bold key={k}>
             {k}:

--- a/src/Entities/Template/EntitySummary.jsx
+++ b/src/Entities/Template/EntitySummary.jsx
@@ -5,7 +5,7 @@ if (!href) {
 }
 
 const { entity, showActions } = props;
-const { accountId, name, displayName, logoUrl, tags } = entity;
+const { namespace, entityType, accountId, name, displayName, logoUrl, tags } = entity;
 const size = props.size || "small";
 
 const sizes = {
@@ -216,7 +216,7 @@ return (
             actionUndoName: "unstar",
             item: {
               type: "social",
-              path: `${accountId}/${entityType}/${name}`,
+              path: `${accountId}/entities/${namespace}/${entityType}/${name}`,
             },
             notifyAccountId: accountId,
             button: (starCount, starIsActive, starOnClick) => (


### PR DESCRIPTION
All entity framework data is now stored in the `social.near` contract under the `entities` key.
The next level below that is a namespace. Entities that don't specify a namespace will go under `default`. Next is the entity type then the entities themselves. So a  myCar `vehicle` entity in the `examples` namespace would be
```
<account_id>: { entities: { examples: { vehicle: { myCar: {...cardata}  } } } }
```
Staring an entity will use a `path` matching the same format.