### PR TITLE
fix: notification counter

### DIFF
--- a/src/NearOrg/Notifications/NotificationButton.jsx
+++ b/src/NearOrg/Notifications/NotificationButton.jsx
@@ -59,18 +59,10 @@ const Button = ({ count }) => {
 };
 
 useEffect(() => {
-  const checkLastBlockHeight = setInterval(() => {
+  const checkNotificationsCountPeriod = setInterval(() => {
     const lastBlockHeight = Storage.get("lastBlockHeight", notificationFeedSrc);
     setLastBlockHeight(lastBlockHeight);
-  }, CHECK_PERIOD);
-  () => {
-    clearInterval(checkLastBlockHeight);
-    setLastBlockHeight(null);
-  };
-}, [notificationFeedSrc]);
 
-useEffect(() => {
-  const checkNotificationsCountPeriod = setInterval(() => {
     const filterUsersRaw = Social.get(
       `${moderatorAccount}/moderate/users`, //TODO
       "optimistic",
@@ -80,14 +72,15 @@ useEffect(() => {
       Social.index("notify", accountId, {
         order: "asc",
         from: (lastBlockHeight ?? 0) + 1,
+        subscribe: true,
       }) || [];
-    const filterNotifications =
-      notifications.lenght > 0 ? notifications.filter((i) => !filterUsers.includes(i.accountId)) : [];
+    const filterNotifications = notifications?.filter((i) => !filterUsers.includes(i.accountId));
     setNotificationsCount(filterNotifications.length || 0);
   }, CHECK_PERIOD);
   () => {
     clearInterval(checkNotificationsCountPeriod);
     setFilterBlockedUsers(null);
+    setLastBlockHeight(null);
   };
 }, [lastBlockHeight, moderatorAccount, accountId]);
 

--- a/src/NearOrg/Notifications/NotificationButton.jsx
+++ b/src/NearOrg/Notifications/NotificationButton.jsx
@@ -1,3 +1,5 @@
+const { fetchGraphQL } = VM.require("${REPL_ACCOUNT}/widget/Entities.QueryApi.Client") || (() => {});
+
 const accountId = context.accountId;
 const notificationFeedSrc = "${REPL_ACCOUNT}/widget/NearOrg.Notifications.NotificationsList";
 
@@ -58,24 +60,44 @@ const Button = ({ count }) => {
   );
 };
 
+const getNotificationsCountQuery = (blockHeight) => `
+  query NotificationsLeftCountQuery {
+    count: dataplatform_near_notifications_notifications_aggregate(where: {receiver: {_eq: "${accountId}"}, blockHeight: {_gt: ${blockHeight}}}, distinct_on: [blockHeight, initiatedBy]) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
 useEffect(() => {
   const checkNotificationsCountPeriod = setInterval(() => {
+    const shouldFallback = Storage.get("notifications:shouldFallback", notificationFeedSrc);
     const lastBlockHeight = Storage.get("lastBlockHeight", notificationFeedSrc);
     setLastBlockHeight(lastBlockHeight);
 
-    const filterUsersRaw = Social.get(
-      `${moderatorAccount}/moderate/users`, //TODO
-      "optimistic",
-    );
-    const filterUsers = filterUsersRaw ? JSON.parse(filterUsersRaw) : [];
-    const notifications =
-      Social.index("notify", accountId, {
-        order: "asc",
-        from: (lastBlockHeight ?? 0) + 1,
-        subscribe: true,
-      }) || [];
-    const filterNotifications = notifications?.filter((i) => !filterUsers.includes(i.accountId));
-    setNotificationsCount(filterNotifications.length || 0);
+    if (shouldFallback) {
+      const filterUsersRaw = Social.get(
+        `${moderatorAccount}/moderate/users`, //TODO
+        "optimistic",
+      );
+      const filterUsers = filterUsersRaw ? JSON.parse(filterUsersRaw) : [];
+      const notifications =
+        Social.index("notify", accountId, {
+          order: "asc",
+          from: (lastBlockHeight ?? 0) + 1,
+          subscribe: true,
+        }) || [];
+      const filterNotifications = notifications?.filter((i) => !filterUsers.includes(i.accountId));
+      setNotificationsCount(filterNotifications.length || 0);
+    }
+
+    fetchGraphQL(getNotificationsCountQuery(lastBlockHeight), "NotificationsLeftCountQuery", {}).then((result) => {
+      if (result.status === 200 && result.body.data) {
+        const { count: notificationsTotal } = result.body.data.count.aggregate;
+        setNotificationsCount(notificationsTotal);
+      }
+    });
   }, CHECK_PERIOD);
   () => {
     clearInterval(checkNotificationsCountPeriod);

--- a/src/NearOrg/Notifications/NotificationsList.jsx
+++ b/src/NearOrg/Notifications/NotificationsList.jsx
@@ -59,9 +59,11 @@ const fetchData = (offset, limit) => {
 
 useEffect(() => {
   if (shouldFallback) {
+    Storage.set("notifications:shouldFallback", true);
     return;
   }
   fetchData(notifications.length, showLimit ?? 10);
+  Storage.set("notifications:shouldFallback", false);
   () => {
     setNotifications([]);
   };


### PR DESCRIPTION
This PR introduces fix for new notifications count. Also, I've added a query to fetch for new notifications from queryApi and not from chain. Fallback logic also included