### PR TITLE
feat: support global tag filtering for entities

### DIFF
--- a/src/Entities/Template/EntityList.jsx
+++ b/src/Entities/Template/EntityList.jsx
@@ -20,9 +20,13 @@ const sortTypes = props.sortTypes ?? [
   { text: "Oldest Updates", value: "{ updated_at: asc }" },
 ];
 
+const initialTagFilter = Storage.get("global-tag-filter");
+if (initialTagFilter) {
+  Storage.set("global-tag-filter", null);
+}
 const [searchKey, setSearchKey] = useState("");
 const [sort, setSort] = useState(sortTypes[0].value);
-const [tagsFilter, setTagsFilter] = useState(null);
+const [tagsFilter, setTagsFilter] = useState(initialTagFilter);
 const [items, setItems] = useState({ list: [], total: 0 });
 const [showCreateModal, setShowCreateModal] = useState(false);
 const [activeItem, setActiveItem] = useState(null);
@@ -244,6 +248,7 @@ return (
             src="${REPL_ACCOUNT}/widget/Entities.Template.Forms.TagsEditor"
             props={{
               placeholder: "Filter by Tag",
+              value: tagsFilter,
               setValue: setTagsFilter,
               namespace: schema.namespace,
               entityType: schema.entityType,

--- a/src/Entities/Template/Forms/TagCloud.jsx
+++ b/src/Entities/Template/Forms/TagCloud.jsx
@@ -1,0 +1,157 @@
+const { loadItems, fetchGraphQL } = VM.require("${REPL_ACCOUNT}/widget/Entities.QueryApi.Client");
+if (!loadItems) {
+  return <p>Loading modules...</p>;
+}
+
+const { namespace, entityType, onSelect, limit } = props;
+const tagLimit = limit ?? 100;
+
+const [items, setItems] = useState(null);
+const [tags, setTags] = useState(value || []);
+
+const user = "dataplatform_near";
+const entityIndexer = "entities";
+const tagsTable = "tags";
+const collection = `${user}_${entityIndexer}_${tagsTable}`;
+
+const buildQueries = () => {
+  const namespaceClause = namespace ? `namespace: {_eq: "${namespace}"}` : "";
+  const entityTypeClause = entityType ? `entity_type: {_eq: "${entityType}"}` : "";
+  const whereClause = namespace || entityType ? `where: {${namespaceClause}, ${entityTypeClause}}` : "";
+
+  return `
+query ListQuery($offset: Int, $limit: Int) {
+  ${collection}(
+      ${whereClause}
+      order_by: {count: desc, tag: asc}, 
+      offset: $offset, limit: $limit) {
+    namespace
+    entity_type
+    tag
+    count
+  }
+  ${collection}_aggregate (
+      ${whereClause}
+    ){
+    aggregate {
+      count
+    }
+  }
+}
+`;
+};
+const queryName = "ListQuery";
+
+const onLoad = (newItems, totalItems) => {
+  // no paging, just top tags
+  setItems({ list: newItems ?? [], total: totalItems });
+};
+loadItems(buildQueries(), queryName, 0, collection, onLoad, tagLimit);
+if (items === null) {
+  return "Loading tags";
+}
+
+const Wrapper = styled.div`
+  position: relative;
+
+  ${(p) =>
+    p.scroll
+      ? `
+    ul {
+      padding-right: 16px;
+    }
+
+    &::after {
+      content: '';
+      display: block;
+      height: 100%;
+      width: 16px;
+      background: linear-gradient(to right, rgba(255,255,255,0), rgba(255,255,255,1));
+      position: absolute;
+      top: 0;
+      right: 0;
+    }
+
+    ul {
+        flex-wrap: nowrap;
+    }
+  `
+      : ""}
+`;
+
+const Tags = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  gap: 6px;
+  overflow: auto;
+  margin: 0;
+  padding: 0;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const Tag = styled.li`
+  padding: 3px 6px;
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 12px;
+  border: 1px solid currentcolor;
+  border-color: ${(p) => (p.primary ? "currentcolor" : "#E6E8EB")};
+  color: ${(p) => (p.primary ? "#26A65A" : "#687076")};
+  font-weight: 500;
+  white-space: nowrap;
+`;
+
+const Count = styled.span`
+  font-family: var(--font-mono);
+  color: #687076;
+  margin-left: 6px;
+`;
+const TooltipTag = styled.span`
+  font-family: var(--font-mono);
+  font-weight: bold;
+  margin-left: 4px;
+`;
+
+const selectTag = (tag) => {
+  if (onSelect) {
+    onSelect(tag);
+  }
+};
+const humanize = (str) => {
+  if (!str) return "";
+  return str.replace(/([A-Z])/g, " $1").replace(/^./, (s) => s.toUpperCase());
+};
+
+return (
+  <div>
+    <p>Filter by Tag</p>
+    <Wrapper scroll={props.scroll}>
+      <Tags>
+        {items && items.list
+          ? items.list.map((tag, i) => (
+              <Widget
+                src="${REPL_ACCOUNT}/widget/DIG.Tooltip"
+                props={{
+                  content: (
+                    <span>
+                      {humanize(tag.entity_type)}s with Tag <TooltipTag> {tag.tag}</TooltipTag>
+                    </span>
+                  ),
+                  trigger: (
+                    <Tag key={i} onClick={() => selectTag(tag)}>
+                      {tag.tag} <Count>{tag.count}</Count>
+                    </Tag>
+                  ),
+                }}
+              />
+            ))
+          : ""}
+      </Tags>
+    </Wrapper>
+  </div>
+);

--- a/src/Entities/Template/GenericEntityConfig.jsx
+++ b/src/Entities/Template/GenericEntityConfig.jsx
@@ -3,7 +3,9 @@ if (!href) {
   return <></>;
 }
 
-const { namespace, entityType, title, schemaFile, homeLink } = props;
+const { namespace, entityType, schemaFile } = props; // data props
+const { title, homeLink } = props; // display props
+
 const schemaLocation = schemaFile ? schemaFile : `${REPL_ACCOUNT}/widget/Entities.Template.GenericSchema`;
 const { genSchema } = VM.require(schemaLocation);
 if (!genSchema) {
@@ -41,7 +43,9 @@ const buildQueries = (searchKey, sort, filters) => {
       if (filter) {
         switch (key) {
           case "tags":
-            queryFilter += `, tags: {_contains: "${arrayInPostgresForm(filter)}"}`;
+            if (filter && filter.length > 0) {
+              queryFilter += `, tags: {_contains: "${arrayInPostgresForm(filter)}"}`;
+            }
             break;
           case "stars":
             queryFilter += `, stars: {_gte: ${filter}}`;

--- a/src/Moderation/Sidebar.jsx
+++ b/src/Moderation/Sidebar.jsx
@@ -7,6 +7,10 @@ const Wrapper = styled.div`
   width: 240px;
   height: 100%;
 `;
+const Section = styled.div`
+  border-top: 1px solid #eceef0;
+  padding-top: 24px;
+`;
 
 const Title = styled.h2`
   font: var(text-l);
@@ -69,5 +73,6 @@ return (
         <Text>{item.name}</Text>
       </MenuItem>
     ))}
+    {props.additionalContent && <Section>{props.additionalContent}</Section>}
   </Wrapper>
 );


### PR DESCRIPTION
 * Used by the AI Nexus, this allows tag filters to be passed from an arbitrary component.
 * Sidebar can have additional content passed
 * TagCloud displays tags and accepts an onSelect handler

<img width="272" alt="Screenshot 2024-04-19 at 4 31 24 PM" src="https://github.com/near/near-discovery-components/assets/671506/f7515fa5-74ed-40a1-9498-e19d3c2f34ce">
