### PR TITLE
chore: cleanup of Post related components

### DIFF
--- a/src/ActivityFeeds/DetermineActivityFeed.jsx
+++ b/src/ActivityFeeds/DetermineActivityFeed.jsx
@@ -1,4 +1,8 @@
-const GRAPHQL_ENDPOINT = props.GRAPHQL_ENDPOINT ?? "https://near-queryapi.api.pagoda.co";
+const { fetchGraphQL, GRAPHQL_ENDPOINT } = VM.require("${REPL_ACCOUNT}/widget/Entities.QueryApi.Client");
+
+if (!fetchGraphQL || !GRAPHQL_ENDPOINT) return <></>;
+
+const LIMIT = 5;
 
 let lastPostSocialApi = Social.index("post", "main", {
   limit: 1,
@@ -13,18 +17,6 @@ State.init({
   // If QueryAPI Feed is lagging behind Social API, fallback to old widget.
   shouldFallback: false,
 });
-
-function fetchGraphQL(operationsDoc, operationName, variables) {
-  return asyncFetch(`${GRAPHQL_ENDPOINT}/v1/graphql`, {
-    method: "POST",
-    headers: { "x-hasura-role": "dataplatform_near" },
-    body: JSON.stringify({
-      query: operationsDoc,
-      variables: variables,
-      operationName: operationName,
-    }),
-  });
-}
 
 const lastPostQuery = `
 query IndexerQuery {
@@ -69,6 +61,7 @@ return (
             props={{
               showFlagAccountFeature: true,
               accounts: props.filteredAccountIds,
+              limit: LIMIT,
             }}
           />
         ) : (
@@ -76,6 +69,7 @@ return (
             src={`${REPL_ACCOUNT}/widget/v1.Posts`}
             props={{
               showFlagAccountFeature: true,
+              limit: LIMIT,
             }}
           />
         )}
@@ -84,8 +78,9 @@ return (
       <Widget
         src={`${REPL_ACCOUNT}/widget/ActivityFeeds.PostsFeedControls`}
         props={{
-          GRAPHQL_ENDPOINT,
+          GRAPHQL_ENDPOINT: props.GRAPHQL_ENDPOINT || GRAPHQL_ENDPOINT,
           showFlagAccountFeature: true,
+          limit: LIMIT,
           ...props,
         }}
       />

--- a/src/ActivityFeeds/DetermineActivityFeed.jsx
+++ b/src/ActivityFeeds/DetermineActivityFeed.jsx
@@ -2,7 +2,7 @@ const { fetchGraphQL, GRAPHQL_ENDPOINT } = VM.require("${REPL_ACCOUNT}/widget/En
 
 if (!fetchGraphQL || !GRAPHQL_ENDPOINT) return <></>;
 
-const LIMIT = 5;
+const LIMIT = 10;
 
 let lastPostSocialApi = Social.index("post", "main", {
   limit: 1,

--- a/src/ActivityFeeds/PostsFeedControls.jsx
+++ b/src/ActivityFeeds/PostsFeedControls.jsx
@@ -1,5 +1,8 @@
-const GRAPHQL_ENDPOINT = props.GRAPHQL_ENDPOINT || "https://near-queryapi.api.pagoda.co";
-const LIMIT = 10;
+const { fetchGraphQL, GRAPHQL_ENDPOINT } = VM.require("${REPL_ACCOUNT}/widget/Entities.QueryApi.Client");
+
+if (!fetchGraphQL || !GRAPHQL_ENDPOINT) return <></>;
+
+const limit = props.limit ?? 10;
 const feeds = props.feeds ?? ["all", "following"];
 const feedLabels = { all: "All", following: "Following", mutual: "Mutual Activity" };
 const showCompose = props.showCompose ?? true;
@@ -86,17 +89,6 @@ const shouldFilter = (item, socialDBObjectType) => {
     }) || matchesModeration(selfModeration, socialDBObjectType, item)
   );
 };
-function fetchGraphQL(operationsDoc, operationName, variables) {
-  return asyncFetch(`${GRAPHQL_ENDPOINT}/v1/graphql`, {
-    method: "POST",
-    headers: { "x-hasura-role": "dataplatform_near" },
-    body: JSON.stringify({
-      query: operationsDoc,
-      variables: variables,
-      operationName: operationName,
-    }),
-  });
-}
 
 const createQuery = (type, isUpdate) => {
   let querySortOption = "";
@@ -214,10 +206,9 @@ const loadMorePosts = (isUpdate) => {
     setIsLoading(true);
   }
   const offset = isUpdate ? 0 : postsData.posts.length;
-  const limit = isUpdate ? 100 : LIMIT;
   fetchGraphQL(createQuery(selectedTab, isUpdate), queryName, {
-    offset: offset,
-    limit: LIMIT,
+    offset,
+    limit,
   }).then((result) => {
     if (result.status === 200 && result.body) {
       if (result.body.errors) {
@@ -550,7 +541,7 @@ return (
                       content: item.content,
                       comments: item.comments,
                       likes: item.accounts_liked,
-                      GRAPHQL_ENDPOINT,
+                      GRAPHQL_ENDPOINT: props.GRAPHQL_ENDPOINT ?? GRAPHQL_ENDPOINT,
                       verifications: item.verifications,
                       showFlagAccountFeature: false,
                     }}

--- a/src/NearOrg/DataAvailabilityPage.jsx
+++ b/src/NearOrg/DataAvailabilityPage.jsx
@@ -507,9 +507,7 @@ return (
                   <Text size="text-xl" mobileSize="text-l" fontWeight="500">
                     Simple to interact with
                   </Text>
-                  <Text>
-                    NEAR readily provides an RPC to easily retrieve the on-chain data from anywhere
-                  </Text>
+                  <Text>NEAR readily provides an RPC to easily retrieve the on-chain data from anywhere</Text>
                 </Flex>
 
                 <div>

--- a/src/v1/Feed.jsx
+++ b/src/v1/Feed.jsx
@@ -3,7 +3,7 @@ const index = {
   action: "post",
   key: "main",
   options: {
-    limit: 10,
+    limit: props.limit ?? 10,
     order: "desc",
     accountId: props.accounts,
   },

--- a/src/v1/Posts.jsx
+++ b/src/v1/Posts.jsx
@@ -155,7 +155,7 @@ return (
       <FeedWrapper>
         <Widget
           src="${REPL_ACCOUNT}/widget/v1.Posts.Feed"
-          props={{ accounts, showFlagAccountFeature: props.showFlagAccountFeature }}
+          props={{ accounts, showFlagAccountFeature: props.showFlagAccountFeature, limit: props.limit }}
         />
       </FeedWrapper>
     </Content>

--- a/src/v1/Posts/Feed.jsx
+++ b/src/v1/Posts/Feed.jsx
@@ -3,7 +3,7 @@ const index = {
   action: "post",
   key: "main",
   options: {
-    limit: 10,
+    limit: props.limit ?? 10,
     order: "desc",
     accountId: props.accounts,
   },


### PR DESCRIPTION
This PR introduces a couple of cleanups of Post related components. As a part of this cleanup, I removed defining of `fetchGraphQL` method in order to use `VM.require()` for exact the same method:

```
const { fetchGraphQL } = VM.require("${REPL_ACCOUNT}/widget/Entities.QueryApi.Client");
```