### PR TITLE
fix: create blogComponentUrl as props to passed to the blog widget

### DIFF
--- a/src/Blog/Feed.jsx
+++ b/src/Blog/Feed.jsx
@@ -1,6 +1,7 @@
 const GRAPHQL_ENDPOINT = props.GRAPHQL_ENDPOINT || "https://near-queryapi.api.pagoda.co";
 
 const contributors = props.contributors || [];
+const blogComponentUrl = props.blogComponentUrl || "bosblog";
 const { requestAuthentication, returnLocation, profileAccountId } = props;
 const [posts, setPosts] = useState([]);
 const promotedPostsQuery = `
@@ -379,7 +380,7 @@ const renderItem = (item, index) => {
 
   return (
     <BlogPage
-      destination={`/bosblog?accountId=${item.account_id}&blockHeight=${item.block_height}&returnLocation=${props.returnLocation}&profileAccountId=${props.profileAccountId}`}
+      destination={`/${blogComponentUrl}?accountId=${item.account_id}&blockHeight=${item.block_height}&returnLocation=${props.returnLocation}&profileAccountId=${props.profileAccountId}`}
     />
   );
 };

--- a/src/BlogPostPage.jsx
+++ b/src/BlogPostPage.jsx
@@ -1,4 +1,5 @@
 const GRAPHQL_ENDPOINT = props.GRAPHQL_ENDPOINT || "https://near-queryapi.api.pagoda.co";
+const blogComponentUrl = props.blogComponentUrl || "bosblog";
 const BlogPostWrapper = styled.div`
   @media (max-width: 1024px) {
     padding-left: 0;
@@ -368,7 +369,7 @@ if (blog) {
     }
   };
 
-  const destination = props.returnLocation + (props.tab === "blog" ? `&tab=blog` : "") || `/bosblog`;
+  const destination = props.returnLocation + (props.tab === "blog" ? `&tab=blog` : "") || `/${blogComponentUrl}`;
 
   return (
     <>

--- a/src/BlogPostPage.jsx
+++ b/src/BlogPostPage.jsx
@@ -369,7 +369,10 @@ if (blog) {
     }
   };
 
-  const destination = props.returnLocation + (props.tab === "blog" ? `&tab=blog` : "") || `/${blogComponentUrl}`;
+  const destination =
+    props.returnLocation && props.tab
+      ? props.returnLocation + (props.tab === "blog" ? `&tab=blog` : "")
+      : `/${blogComponentUrl}`;
 
   return (
     <>


### PR DESCRIPTION
Companion to [#1175](https://github.com/near/near-discovery/pull/1175) allowing for a gateway to set a custom url for their bosblog page implementation. Original request can be found [here](https://github.com/orgs/near/projects/92/views/6?pane=issue&itemId=61052380)

Also fixes [Bug](https://github.com/orgs/near/projects/92/views/6?pane=issue&itemId=61053805) where the "back to all posts" button url was undefined resulting in a broken link.