### PR TITLE
feat: add nearcatalog records to improve search ux

### DIFF
--- a/src/Search/ComponentCard.jsx
+++ b/src/Search/ComponentCard.jsx
@@ -1,7 +1,14 @@
 const [accountId, widget, widgetName] = props.src.split("/");
-const metadata = Social.get(`${accountId}/widget/${widgetName}/metadata/**`, "final");
-const detailsUrl = `/${REPL_ACCOUNT}/widget/ComponentDetailsPage?src=${accountId}/widget/${widgetName}`;
+const variant = props.variant ?? "default";
+const metadata =
+  variant === "nearcatalog"
+    ? { image: props.image, name: props.name }
+    : Social.get(`${accountId}/widget/${widgetName}/metadata/**`, "final");
 const appUrl = `/${accountId}/widget/${widgetName}`;
+const detailsUrl =
+  variant === "nearcatalog"
+    ? appUrl
+    : `/${REPL_ACCOUNT}/widget/ComponentDetailsPage?src=${accountId}/widget/${widgetName}`;
 const accountUrl = `/${REPL_ACCOUNT}/widget/ProfilePage?accountId=${accountId}`;
 const onPointerUp =
   props.onClick ??

--- a/src/Search/FullPage/ComponentCard.jsx
+++ b/src/Search/FullPage/ComponentCard.jsx
@@ -1,8 +1,15 @@
 const [accountId, widget, widgetName] = props.src.split("/");
-const metadata = Social.get(`${accountId}/widget/${widgetName}/metadata/**`, "final");
-const tags = Object.keys(metadata.tags || {});
-const detailsUrl = `/${REPL_ACCOUNT}/widget/ComponentDetailsPage?src=${accountId}/widget/${widgetName}`;
+const variant = props.variant ?? "default";
+const metadata =
+  variant === "nearcatalog"
+    ? { image: props.image, name: props.name, tags: props.tags }
+    : Social.get(`${accountId}/widget/${widgetName}/metadata/**`, "final");
+const tags = metadata.tags && Array.isArray(metadata.tags) ? metadata.tags : Object.keys(metadata.tags || {});
 const appUrl = `/${accountId}/widget/${widgetName}`;
+const detailsUrl =
+  variant === "nearcatalog"
+    ? appUrl
+    : `/${REPL_ACCOUNT}/widget/ComponentDetailsPage?src=${accountId}/widget/${widgetName}`;
 const accountUrl = `/${REPL_ACCOUNT}/widget/ProfilePage?accountId=${accountId}`;
 const onPointerUp =
   props.onClick ??
@@ -153,7 +160,7 @@ const ButtonLink = styled("Link")`
 
 return (
   <Card>
-    {
+    {variant !== "nearcatalog" && (
       <CardTag>
         <i className="bi bi-clock"></i>{" "}
         <Widget
@@ -165,7 +172,7 @@ return (
         />{" "}
         ago
       </CardTag>
-    }
+    )}
 
     <CardBody>
       <Thumbnail href={detailsUrl} onPointerUp={onPointerUp}>

--- a/src/Search/Insights.jsx
+++ b/src/Search/Insights.jsx
@@ -43,7 +43,7 @@ window.addEventListener("message", (message) => {
 return (
   <iframe
     srcDoc={code}
-    style={{ position: absolute, width: 0, height: 0, border: 0 }}
+    style={{ position: "absolute", width: 0, height: 0, border: 0 }}
     message={{ event: props.event }}
     onMessage={(resp) => onChange(resp)}
   />

--- a/src/Search/TypeAheadDropdown.jsx
+++ b/src/Search/TypeAheadDropdown.jsx
@@ -1,9 +1,9 @@
-const SEARCH_API_KEY = props.searchApiKey ?? "0e42c01107b8f555a41bcc0fa7f2a4df";
+const SEARCH_API_KEY = props.searchApiKey ?? "fc7644a5da5306311e8e9418c24fddc4";
 const APPLICATION_ID = props.appId ?? "B6PI9UKKJT";
-const INDEX = props.index ?? "prod_near-social-feed";
+const INDEX = props.index ?? "replica_prod_near-social-feed";
 const API_URL = props.apiUrl ?? `https://${APPLICATION_ID}-dsn.algolia.net/1/indexes/${INDEX}/query?`;
 const INITIAL_PAGE = props.initialPage ?? 0;
-const facets = props.facets ?? ["All", "People", "Apps", "Components", "Posts"];
+const facets = props.facets ?? ["All", "People", "Apps", "Components", "Posts", "NEARCatalog"];
 const tab = props.tab ?? "All";
 const showHeader = props.showHeader ?? true;
 const showSearchBar = props.showSearchBar ?? true;
@@ -84,8 +84,15 @@ const FixedTabs = styled.div`
 `;
 
 const H2 = styled.h2`
+  display: ${(p) => p.$display ?? "block"};
+  justify-content: ${(p) => p.$justifyContent ?? "flex-start"};
+  align-items: ${(p) => p.$alignItems ?? "flex-start"};
+  position: ${(p) => p.$position ?? "relative"};
+  top: ${(p) => p.$top ?? "0"};
+  left: ${(p) => p.$left ?? "0"};
+  width: ${(p) => p.$width ?? "auto"};
   font-weight: 400;
-  font-size: 20px;
+  font-size: ${(p) => p.$fontSize ?? "20px"};
   line-height: 24px;
   color: #687076;
   margin: 0;
@@ -224,6 +231,40 @@ const ScrollableContent = styled.div`
 
 const Item = styled.div``;
 
+const DisplayResultsByFacet = ({ title, count, items }) => (
+  <Group>
+    <GroupHeader>
+      <H3>
+        {title}
+        <span
+          style={{
+            marginLeft: "10px",
+          }}
+        >
+          {count}
+        </span>
+      </H3>
+    </GroupHeader>
+    <Items>{items}</Items>
+  </Group>
+);
+
+const TextMessage = ({ message, ...props }) => (
+  <H2
+    $display="flex"
+    $justifyContent="center"
+    $alignItems="center"
+    $position="absolute"
+    $fontSize="15px"
+    $width="100%"
+    $top="40%"
+    $left="-0%"
+    {...props}
+  >
+    {message}
+  </H2>
+);
+
 //*********SEARCH FUNCTIONS ******** */
 
 // Reset Search Results
@@ -236,6 +277,7 @@ const resetSearcheHits = () => {
     apps: undefined,
     components: undefined,
     postsAndComments: undefined,
+    nearcatalog: undefined,
   });
 };
 
@@ -298,6 +340,24 @@ const components = (records, app) => {
       app,
       accountId,
       widgetName,
+      searchPosition: i,
+    });
+  }
+  return components;
+};
+
+// creates an array of components
+const nearcatalog = (records) => {
+  const components = [];
+  for (const [i, component] of records || []) {
+    const widgetName = "Index";
+    const accountId = "nearcatalog.near";
+    components.push({
+      accountId,
+      widgetName,
+      slug: component.slug,
+      image: component.image,
+      name: component.name,
       searchPosition: i,
     });
   }
@@ -389,6 +449,16 @@ const updateSearchHits = debounce(({ term, pageNumber }) => {
             queryID: resp.body.queryID,
           },
         });
+      } else if (facet === "NEARCatalog") {
+        console.log("updateStateAfterFetching facet: ", facet);
+        State.update({
+          nearcatalog: {
+            hitsTotal,
+            hitsPerPage,
+            hits: nearcatalog(results["nearcatalog"]),
+            queryID: resp.body.queryID,
+          },
+        });
       } else {
         State.update({
           postsAndComments: {
@@ -413,7 +483,7 @@ const updateSearchHits = debounce(({ term, pageNumber }) => {
     };
   };
 
-  for (const facet of ["People", "Apps", "Components", "Posts"]) {
+  for (const facet of facets.filter((i) => i !== "All")) {
     fetchSearchHits(term, {
       pageNumber,
       configs: configsPerFacet(facet),
@@ -431,6 +501,7 @@ const FACET_TO_CATEGORY = {
   Apps: "app",
   Components: "widget",
   Posts: "post",
+  NEARCatalog: "nearcatalog",
 };
 
 const FACET_TO_FILTER = {
@@ -438,6 +509,7 @@ const FACET_TO_FILTER = {
   Apps: "(categories:app OR tags:app)",
   Components: "categories:widget",
   Posts: "(categories:post OR categories:comment)",
+  NEARCatalog: "categories:nearcatalog",
 };
 
 const searchFilters = (facet) => {
@@ -553,6 +625,9 @@ const tabCount = (tab) => {
     case "Posts":
       // Return the count for Posts
       return state.postsAndComments.hitsTotal ?? 0;
+    case "NEARCatalog":
+      // Return the count for NEARCatalog
+      return state.nearcatalog.hitsTotal ?? 0;
     default:
       // Return 0 if the tab name is not in the list
       return 0;
@@ -588,6 +663,36 @@ const topmostComponents = (apps) => {
               queryID,
               searchPosition: component.searchPosition,
               objectID: `${component.accountId}/widget/${component.widgetName}`,
+              eventName: `Clicked ${eventName} After Search`,
+            }),
+        }}
+      />
+    </Item>
+  ));
+};
+
+const topmostNEARCatalogComponents = () => {
+  let output = state.nearcatalog.hits.slice(0, 5);
+
+  const queryID = state.nearcatalog.queryID;
+  const eventName = "Component";
+  return output.map((component, i) => (
+    <Item
+      key={`${component.accountId}/widget/${component.widgetName}/${component.slug}`}
+      onClick={handleCloseSearchMenu}
+    >
+      <Widget
+        src="${REPL_ACCOUNT}/widget/Search.ComponentCard"
+        props={{
+          src: `${component.accountId}/widget/${component.widgetName}?id=${component.slug}`,
+          variant: "nearcatalog",
+          name: component.name,
+          image: component.image,
+          onClick: () =>
+            onSearchResultClick({
+              queryID,
+              searchPosition: component.searchPosition,
+              objectID: `${component.accountId}/widget/${component.widgetName}?id=${component.slug}`,
               eventName: `Clicked ${eventName} After Search`,
             }),
         }}
@@ -636,243 +741,87 @@ const displayResultsByFacet = (selectedTab) => {
   switch (selectedTab) {
     case "People":
       return state.profiles.hits?.length > 0 ? (
-        <Group>
-          <GroupHeader>
-            <H3>
-              People
-              <span
-                style={{
-                  marginLeft: "10px",
-                }}
-              >
-                {state.profiles.hitsTotal}
-              </span>
-            </H3>
-          </GroupHeader>
-
-          <Items>{topmostAccounts()}</Items>
-        </Group>
+        <DisplayResultsByFacet title="People" count={state.profiles.hitsTotal} items={topmostAccounts()} />
       ) : (
-        <H2
-          style={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            position: "absolute",
-            top: "40%", // Adjust this value to position the text lower
-            width: "100%",
-            fontSize: "15px",
-            left: "-0%",
-          }}
-        >
-          No People matches were found for "{state.term}".
-        </H2>
+        <TextMessage message={`No People matches were found for "${state.term}".`} />
       );
     case "Apps": {
       return state.apps.hits?.length > 0 ? (
-        <Group>
-          <GroupHeader>
-            <H3>
-              Apps
-              <span
-                style={{
-                  marginLeft: "10px",
-                }}
-              >
-                {state.apps.hitsTotal}
-              </span>
-            </H3>
-          </GroupHeader>
-          <Items>{topmostComponents(true)}</Items>
-        </Group>
+        <DisplayResultsByFacet title="Apps" count={state.apps.hitsTotal} items={topmostComponents(true)} />
       ) : (
         <>
-          <H2
-            style={{
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-              position: "absolute",
-              top: "40%", // Adjust this value to position the text lower
-              width: "100%",
-              fontSize: "15px",
-              left: "-0%",
-            }}
-          >
-            No App matches were found for "{state.term}".
-          </H2>
-          <H2
-            style={{
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-              position: "absolute",
-              top: "45%", // Adjust this value to position the text lower
-              width: "100%",
-              fontSize: "12px",
-              left: "-0%",
-            }}
-          >
-            Trying to find a app built by an user? Try search their account id.
-          </H2>{" "}
+          <TextMessage message={`No App matches were found for "${state.term}".`} />
+          <TextMessage
+            message={`Trying to find a app built by an user? Try search their account id.`}
+            $fontSize="12px"
+            $top="45%"
+          />{" "}
         </>
       );
     }
 
     case "Components":
       return state.components.hits?.length > 0 ? (
-        <Group>
-          <GroupHeader>
-            <H3>
-              Components
-              <span
-                style={{
-                  marginLeft: "10px",
-                }}
-              >
-                {state.components.hitsTotal}
-              </span>
-            </H3>
-          </GroupHeader>
-
-          <Items>{topmostComponents(false)}</Items>
-        </Group>
+        <DisplayResultsByFacet title="Components" count={state.components.hitsTotal} items={topmostComponents(false)} />
       ) : (
         <>
-          <H2
-            style={{
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-              position: "absolute",
-              top: "40%", // Adjust this value to position the text lower
-              width: "100%",
-              fontSize: "15px",
-              left: "-0%",
-            }}
-          >
-            No Component matches were found for "{state.term}".
-          </H2>
-          <H2
-            style={{
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-              position: "absolute",
-              top: "45%", // Adjust this value to position the text lower
-              width: "100%",
-              fontSize: "12px",
-              left: "-0%",
-            }}
-          >
-            Trying to find a app built by an user? Try search their account id.
-          </H2>{" "}
+          <TextMessage message={`No Component matches were found for "${state.term}".`} />
+          <TextMessage
+            message={`Trying to find a app built by an user? Try search their account id.`}
+            $fontSize="12px"
+            $top="45%"
+          />{" "}
         </>
+      );
+    case "NEARCatalog":
+      return state.nearcatalog.hits?.length > 0 ? (
+        <DisplayResultsByFacet
+          title="NEARCatalog"
+          count={state.nearcatalog.hitsTotal}
+          items={topmostNEARCatalogComponents()}
+        />
+      ) : (
+        <TextMessage message={`No NEARCatalog components matches were found for "${state.term}".`} />
       );
     case "Posts":
       return state.postsAndComments.hits?.length > 0 ? (
-        <Group style={{ marginTop: "20px" }}>
-          <GroupHeader>
-            <H3>
-              Posts and Comments
-              <span
-                style={{
-                  marginLeft: "10px",
-                }}
-              >
-                {state.postsAndComments.hitsTotal}
-              </span>
-            </H3>
-          </GroupHeader>
-
-          <Items>{topmostPosts()}</Items>
-        </Group>
+        <DisplayResultsByFacet
+          title="Posts and Comments"
+          count={state.postsAndComments.hitsTotal}
+          items={topmostPosts()}
+        />
       ) : (
-        <H2
-          style={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            position: "absolute",
-            top: "40%", // Adjust this value to position the text lower
-            width: "100%",
-            fontSize: "15px",
-            left: "-0%",
-          }}
-        >
-          No Post matches were found for "{state.term}".
-        </H2>
+        <TextMessage message={`No Post matches were found for "${state.term}".`} />
       );
     case "All":
       return (
         <>
           {state.profiles.hits?.length > 0 && (
-            <Group>
-              <GroupHeader>
-                <H3>
-                  People
-                  <span
-                    style={{
-                      marginLeft: "10px",
-                    }}
-                  >
-                    {state.profiles.hitsTotal}
-                  </span>
-                </H3>
-              </GroupHeader>
-              <Items>{topmostAccounts()}</Items>
-            </Group>
+            <DisplayResultsByFacet title="People" count={state.profiles.hitsTotal} items={topmostAccounts()} />
           )}
           {state.apps.hits?.length > 0 && (
-            <Group>
-              <GroupHeader>
-                <H3>
-                  Apps
-                  <span
-                    style={{
-                      marginLeft: "10px",
-                    }}
-                  >
-                    {state.apps.hitsTotal}
-                  </span>
-                </H3>
-              </GroupHeader>
-              <Items>{topmostComponents(true)}</Items>
-            </Group>
+            <DisplayResultsByFacet title="Apps" count={state.apps.hitsTotal} items={topmostComponents(true)} />
           )}
           {state.components.hits?.length > 0 && (
-            <Group>
-              <GroupHeader>
-                <H3>
-                  Components
-                  <span
-                    style={{
-                      marginLeft: "10px",
-                    }}
-                  >
-                    {state.components.hitsTotal}
-                  </span>
-                </H3>
-              </GroupHeader>
-              <Items>{topmostComponents(false)}</Items>
-            </Group>
+            <DisplayResultsByFacet
+              title="Components"
+              count={state.components.hitsTotal}
+              items={topmostComponents(false)}
+            />
           )}
           {state.postsAndComments.hits?.length > 0 && (
-            <Group style={{ marginTop: "20px" }}>
-              <GroupHeader>
-                <H3>
-                  Posts and Comments
-                  <span
-                    style={{
-                      marginLeft: "10px",
-                    }}
-                  >
-                    {state.postsAndComments.hitsTotal}
-                  </span>
-                </H3>
-              </GroupHeader>
-              <Items>{topmostPosts()}</Items>
-            </Group>
+            <DisplayResultsByFacet
+              title="Posts and Comments"
+              count={state.postsAndComments.hitsTotal}
+              items={topmostPosts()}
+            />
+          )}
+          {state.nearcatalog.hits?.length > 0 && (
+            <DisplayResultsByFacet
+              title="NEARCatalog"
+              count={state.nearcatalog.hitsTotal}
+              items={topmostNEARCatalogComponents()}
+            />
           )}
         </>
       );


### PR DESCRIPTION
This PR introduces changes for Algoria search. `replica_prod_near-social-feed` includes two indexes:

- `prod_near-social-feed` (production records);
- `test-near-catalog-index` (nearcatalog records);

[loom](https://www.loom.com/share/f59a0a634dd0491da471d8ce3ddc5089?sid=c9c50cde-b0d9-4fde-bf4c-05582bc7f29a) video

Closes https://github.com/near/docs/issues/1941