### PR TITLE
fix: search input focus issue

### DIFF
--- a/src/Navigation/Search.jsx
+++ b/src/Navigation/Search.jsx
@@ -13,19 +13,21 @@ const handleInteractOutside = (e) => {
 };
 
 return (
-  <Popover.Root open={showTypeAheadDropdown}>
-    <Popover.Trigger asChild>
+  <HoverCard.Root openDelay={200} closeDelay={300} open={showTypeAheadDropdown}>
+    <HoverCard.Trigger asChild>
       <div>
         <Widget
           src="${REPL_ACCOUNT}/widget/DIG.InputSearch"
           props={{
             onQueryChange: handleOnInput,
             placeholder: "Search NEAR",
+            onBlur: () => setIsFocused(false),
+            onFocus: () => setIsFocused(true),
           }}
         />
       </div>
-    </Popover.Trigger>
-    <Popover.Content asChild onInteractOutside={handleInteractOutside} onOpenAutoFocus={() => {}}>
+    </HoverCard.Trigger>
+    <HoverCard.Content asChild side="bottom" sideOffset={10} hideWhenDetached={true}>
       <div>
         <Widget
           src="${REPL_ACCOUNT}/widget/Search.TypeAheadDropdown"
@@ -35,6 +37,6 @@ return (
           }}
         />
       </div>
-    </Popover.Content>
-  </Popover.Root>
+    </HoverCard.Content>
+  </HoverCard.Root>
 );


### PR DESCRIPTION
This PR addresses an issue where the search bar frequently loses focus. This problem was causing frustration for users who needed to repeatedly click on the input bar to continue typing and see auto-suggestions.

Check out this [message](https://pagodaplatform.slack.com/archives/C0559BC3WBZ/p1717521230244739) for additional context.