### PR TITLE
Generalise devhub mutiple instances notifications

### DIFF
--- a/src/NearOrg/Notifications/Notification.jsx
+++ b/src/NearOrg/Notifications/Notification.jsx
@@ -183,7 +183,11 @@ if (value === null) return "Loading...";
 const notificationType = value?.type;
 const notifier = value?.notifier;
 
-const showAuthorProfile = notificationType == "devhub/mention" || notificationType == "devhub/edit";
+const showAuthorProfile =
+  notificationType == "proposal/mention" ||
+  notificationType == "proposal/edit" ||
+  notificationType == "rfp/mention" ||
+  notificationType == "rfp/edit";
 // notifier is the one who should be displayed as profile in notifications,
 // since all the notifications will be created by devhub.near account but the actual person initiating it is the notifier
 if (showAuthorProfile) {
@@ -199,7 +203,7 @@ const profileUrl = `/${REPL_ACCOUNT}/widget/ProfilePage?accountId=${accountId}`;
 // which means it's not actionable
 // as for example "like", "comment", "star", "custom",
 // "devgovgigs/mention", "devgovgigs/edit", "devgovgigs/reply", "devgovgigs/like"
-// "devhub/mention", "devhub/edit", "devhub/reply", "devhub/like"
+// "proposal/mention", "proposal/edit", "proposal/reply", "proposal/like", "rfp/mention", "rfp/edit", "rfp/reply", "rfp/like"
 const ordinaryNotification = ["follow", "unfollow", "poke"].indexOf(notificationType) >= 0;
 
 // Assert is a valid type

--- a/src/NearOrg/Notifications/utils.jsx
+++ b/src/NearOrg/Notifications/utils.jsx
@@ -30,13 +30,17 @@ function createNotificationMessage(value) {
     case "comment":
     case "devgovgigs/reply":
       return "replied to your post";
-    case "devhub/reply":
+    case "proposal/reply":
       return "replied to your proposal";
+    case "rfp/reply":
+      return "replied to your RFP";
     case "mention":
     case "devgovgigs/mention":
       return "mentioned you in their post";
-    case "devhub/mention":
+    case "proposal/mention":
       return "mentioned you in their proposal";
+    case "rfp/mention":
+      return "mentioned you in their RFP";
     case "poke":
       return "poked you";
     case "star":
@@ -44,12 +48,16 @@ function createNotificationMessage(value) {
     case "custom":
       return customMessage ?? "";
     case "devgovgigs/edit":
-    case "devhub/edit":
-      return "edited your post";
+    case "proposal/edit":
+      return "edited your proposal";
+    case "rfp/edit":
+      return "edited the RFP";
     case "devgovgigs/like":
       return isDevHubPost ? "liked your post" : "liked your comment";
-    case "devhub/like":
+    case "proposal/like":
       return "liked your proposal";
+    case "rfp/like":
+      return "liked the RFP";
     default:
       return null;
   }
@@ -95,6 +103,8 @@ function createNotificationLink(notificationValue, authorAccountId, accountId, b
   const params = notificationValue?.params ?? {};
   const post = notificationValue?.post ?? {};
   const proposal = notificationValue?.proposal ?? "";
+  const rfp = notificationValue?.rfp ?? "";
+  const widgetAccountId = notificationValue?.widgetAccountId ?? "";
   const likeAtBlockHeight = notificationValue?.item?.blockHeight ?? undefined;
   const path = notificationValue?.item?.path ?? "";
 
@@ -127,15 +137,26 @@ function createNotificationLink(notificationValue, authorAccountId, accountId, b
           id: post,
         },
       });
-    case "devhub/mention":
-    case "devhub/edit":
-    case "devhub/reply":
-    case "devhub/like":
+    case "proposal/mention":
+    case "proposal/edit":
+    case "proposal/reply":
+    case "proposal/like":
       return href({
-        widgetSrc: "devhub.near/widget/app",
+        widgetSrc: `${widgetAccountId}/widget/app`,
         params: {
           page: "proposal",
           id: proposal,
+        },
+      });
+    case "rfp/mention":
+    case "rfp/edit":
+    case "rfp/reply":
+    case "rfp/like":
+      return href({
+        widgetSrc: `${widgetAccountId}/widget/app`,
+        params: {
+          page: "rfp",
+          id: rfp,
         },
       });
     default:
@@ -147,7 +168,8 @@ function getNotificationIconClassName(notificationType) {
   switch (notificationType) {
     case "like":
     case "devgovgigs/like":
-    case "devhub/like":
+    case "proposal/like":
+    case "rfp/like":
       return "ph ph-heart";
     case "fork":
       return "ph ph-git-fork";
@@ -157,11 +179,13 @@ function getNotificationIconClassName(notificationType) {
       return "ph ph-user-minus";
     case "comment":
     case "devgovgigs/reply":
-    case "devhub/reply":
+    case "proposal/reply":
+    case "rfp/reply":
       return "ph ph-share-fat";
     case "mention":
     case "devgovgigs/mention":
-    case "devhub/mention":
+    case "proposal/mention":
+    case "rfp/mention":
       return "ph ph-at";
     case "poke":
       return "ph ph-hand-pointing";
@@ -196,6 +220,7 @@ function checkNotificationValueAvailability(value) {
   const post = value?.post ?? null;
   const notifier = value?.notifier ?? null;
   const proposal = value?.proposal ?? null;
+  const rfp = value?.rfp ?? null;
 
   switch (notificationType) {
     case "like":
@@ -213,13 +238,20 @@ function checkNotificationValueAvailability(value) {
     case "devgovgigs/mention":
     case "devgovgigs/edit":
       return !(!type || !post);
-    case "devhub/like":
+    case "proposal/like":
       return !(!type || !proposal);
-    case "devhub/edit":
-    case "devhub/mention":
+    case "rfp/like":
+      return !(!type || !rfp);
+    case "proposal/edit":
+    case "proposal/mention":
       return !(!type || !notifier || !proposal);
-    case "devhub/reply":
+    case "rfp/edit":
+    case "rfp/mention":
+      return !(!type || !notifier || !rfp);
+    case "proposal/reply":
       return !(!type || !path || !blockHeight || !proposal);
+    case "rfp/reply":
+      return !(!type || !path || !blockHeight || !rfp);
     default:
       return false;
   }


### PR DESCRIPTION
Generalise proposal and RFP notifications to following keys:
```
"proposal/mention", "proposal/edit", "proposal/reply", "proposal/like", "rfp/mention", "rfp/edit", "rfp/reply", "rfp/like"
```
we will use `widgetAccountId` to navigate user to specific instance widgets 