### PR TITLE
chore: reduce amount of search categories (Part 1/2)

### DIFF
--- a/src/Navigation/NameDropdown.jsx
+++ b/src/Navigation/NameDropdown.jsx
@@ -49,7 +49,7 @@ return (
   <Widget
     src="${REPL_ACCOUNT}/widget/DIG.DropdownMenu"
     props={{
-      trigger: profile.name,
+      trigger: profile.name || accountId,
       items: menuItems,
     }}
   />

--- a/src/Navigation/NameDropdown.jsx
+++ b/src/Navigation/NameDropdown.jsx
@@ -46,13 +46,11 @@ const menuItems = [
 ];
 
 return (
-    <Widget
-      src="${REPL_ACCOUNT}/widget/DIG.DropdownMenu"
-      props={{
-        trigger: (
-          profile.name
-        ),
-        items: menuItems,
-      }}
-    />
+  <Widget
+    src="${REPL_ACCOUNT}/widget/DIG.DropdownMenu"
+    props={{
+      trigger: profile.name,
+      items: menuItems,
+    }}
+  />
 );

--- a/src/Navigation/ProfileDropdown.jsx
+++ b/src/Navigation/ProfileDropdown.jsx
@@ -1,9 +1,31 @@
-let { accountId, profile, availableStorage, withdrawTokens, logOut } = props;
+let { accountId, profile, availableStorage, withdrawTokens, logOut, noProfileName } = props;
 
 accountId = accountId ?? context.accountId;
 profile = profile ?? Social.get(`${accountId}/profile/**`, "final");
 
 const profilePage = `/${REPL_ACCOUNT}/widget/ProfilePage?accountId=${accountId}`;
+
+const Text = styled.span`
+  margin: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-size: 14px;
+  overflow: ${(p) => (p.$ellipsis ? "hidden" : "")};
+  text-overflow: ${(p) => (p.$ellipsis ? "ellipsis" : "")};
+  white-space: ${(p) => (p.$ellipsis ? "nowrap" : "")};
+`;
+const Flex = styled.div`
+  display: flex;
+  gap: ${(p) => p.$gap};
+  align-items: ${(p) => p.$alignItems};
+  justify-content: ${(p) => p.$justifyContent};
+  flex-direction: ${(p) => p.$direction ?? "row"};
+  flex-wrap: ${(p) => p.$wrap ?? "nowrap"};
+
+  @media (max-width: 576px) {
+    gap: 10px;
+  }
+`;
 
 const handleWithdraw = () => {
   if (withdrawTokens) {
@@ -50,14 +72,21 @@ return (
     src="${REPL_ACCOUNT}/widget/DIG.DropdownMenu"
     props={{
       trigger: (
-        <Widget
-          src="${REPL_ACCOUNT}/widget/DIG.Avatar"
-          props={{
-            alt: accountId,
-            image: profile.image,
-            style: { width: "40px", height: "40px" },
-          }}
-        />
+        <Flex $gap="8px" $alignItems="center">
+          <Widget
+            src="${REPL_ACCOUNT}/widget/DIG.Avatar"
+            props={{
+              alt: accountId,
+              image: profile.image,
+              style: { width: "40px", height: "40px" },
+            }}
+          />
+          {!noProfileName && (
+            <Text $ellipsis className="profile-dropdown-name">
+              {profile.name || accountId.split(".near")[0]}
+            </Text>
+          )}
+        </Flex>
       ),
       items: menuItems,
     }}

--- a/src/Navigation/Search.jsx
+++ b/src/Navigation/Search.jsx
@@ -1,3 +1,4 @@
+let { placeholder } = props;
 const [value, setValue] = useState("");
 const [isFocused, setIsFocused] = useState(false);
 const [isCursorOutside, setIsCursorOutside] = useState(false);
@@ -29,7 +30,7 @@ return (
           src="${REPL_ACCOUNT}/widget/DIG.InputSearch"
           props={{
             onQueryChange: handleOnInput,
-            placeholder: "Search NEAR",
+            placeholder: placeholder ?? "Search NEAR",
             onBlur: handleOnBlur,
             onFocus: handleFocusChange,
           }}

--- a/src/Search/ComponentCard.jsx
+++ b/src/Search/ComponentCard.jsx
@@ -18,7 +18,7 @@ const onPointerUp =
     }
   });
 
-const Card = styled("Link")`
+const Card = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
As per discussion with @charleslavon we decided to proceed with this https://github.com/near/near-discovery/issues/1196 issue by this way:

1. Remove search categories such as "posts", "posts-and-comments", "people" and leave **only** components including nearcatalog and widgets (about widgets I'm not sure, because don't remember);
2. Bring the top navbar back along with search (this is the **part 2** on the near-discovery side);

Closes https://github.com/near/near-discovery/issues/1196

Feel free to leave any questions you have!