### PR TITLE
fix: display accountId when profile don't exist

### DIFF
--- a/src/Navigation/NameDropdown.jsx
+++ b/src/Navigation/NameDropdown.jsx
@@ -50,7 +50,7 @@ return (
       src="${REPL_ACCOUNT}/widget/DIG.DropdownMenu"
       props={{
         trigger: (
-          profile.name
+          profile.name || accountId
         ),
         items: menuItems,
       }}


### PR DESCRIPTION
Currently, if the user has not created a profile, the menu will display "Trigger" since that is the default text displayed by `DIG.DropdownMenu`

This PR fixes it by displaying the AccountId if no profile exist