### PR TITLE
chore: adds an invisible link to be used by playwright automation

### DIFF
--- a/src/Gateway/Home.jsx
+++ b/src/Gateway/Home.jsx
@@ -462,5 +462,6 @@ return (
         </Grid>
       </Container>
     </Section>
+    <a href="/sandbox" />
   </Wrapper>
 );


### PR DESCRIPTION
This link is invisible for regular users. This is an interesting story and the tl;dr; is that I need to use playwright on dev.near.org to automate using the sandbox to repeatedly submit transactions to be able to efficiently burn through the[ trial-account](https://docs.keypom.xyz/docs/next/TrialAccounts/introduction) floor of 10 Near that I set on couple keypom accounts. 