### PR TITLE
Revert "chore: adds an invisible link to be used by playwright automation"

### DIFF
--- a/src/Gateway/Home.jsx
+++ b/src/Gateway/Home.jsx
@@ -462,6 +462,5 @@ return (
         </Grid>
       </Container>
     </Section>
-    <a href="/sandbox" />
   </Wrapper>
 );


### PR DESCRIPTION
Reverts near/near-discovery-components#845

I think I can accomplish this directly via playwright code ```await page.setContent(`<style>
      a {
        zoom: 100%
      }
      </style>
      <a href="/sandbox/>
      `);